### PR TITLE
Streamflow points sidebar populating with points

### DIFF
--- a/client/src/components/MapFilters.vue
+++ b/client/src/components/MapFilters.vue
@@ -37,11 +37,35 @@
                 ></q-menu>
             </q-btn>
         </div>
-        <div v-for="point in pointsToShow" :key="point.properties.id">
-            <hr />
-            <pre>{{ point.properties.nid }}</pre>
-            <pre>{{ point.properties }}</pre>
-        </div>
+        <!-- The max-height property of this to determine how much content to render in the virtual scroll -->
+        <q-virtual-scroll
+            :items="pointsToShow"
+            v-slot="{ item, index }"
+            style="max-height: 90%;"
+            separator
+            :virtual-scroll-item-size="50"
+        >
+            <q-item
+                :key="index"
+                clickable
+                @mouseover="() => console.log(item.properties.id)"
+            >
+                <q-item-section>
+                    <q-item-label>
+                        Allocation ID: {{ item.properties.nid }}
+                    </q-item-label>
+                    <q-item-label :style="`color: white;`" caption>
+                        ID: {{ item.properties.id }}
+                    </q-item-label>
+                    <q-item-label :style="`color: white;`" caption>
+                        Net: {{ item.properties.net }}
+                    </q-item-label>
+                    <q-item-label :style="`color: white;`" caption>
+                        Type: {{ item.properties.type }}
+                    </q-item-label>
+                </q-item-section>
+            </q-item>
+        </q-virtual-scroll>
     </div>
 </template>
 

--- a/client/src/components/streamflow/Streamflow.vue
+++ b/client/src/components/streamflow/Streamflow.vue
@@ -49,13 +49,14 @@ import Map from "@/components/Map.vue";
 import MapFilters from "@/components/MapFilters.vue";
 import { highlightLayer, pointLayer } from "@/constants/mapLayers.js";
 import points from "@/constants/streamflow.json";
-import { ref } from "vue";
+import { nextTick, ref } from "vue";
 import StreamflowReport from "./StreamflowReport.vue";
 
 const map = ref();
 const activePoint = ref();
 const features = ref([]);
 const reportOpen = ref(false);
+const visiblePoints = ref([]);
 const streamflowFilters = ref({
     buttons: [
         {
@@ -177,7 +178,26 @@ const loadPoints = (mapObj) => {
     map.value.on("mouseleave", "point-layer", () => {
         map.value.getCanvas().style.cursor = "";
     });
+
+    map.value.on('moveend', () => {
+        nextTick(() => {
+            getVisibleLicenses();
+        });
+    })
+
+    map.value.once('idle',  () => {
+        getVisibleLicenses();
+    })
 };
+
+/**
+ * Gets the licenses currently in the viewport of the map
+ */
+const getVisibleLicenses = () => {
+    features.value = map.value.queryRenderedFeatures({ 
+        layers: ['point-layer'],
+    });
+}
 
 /**
  * Dismiss the map popup and clear the highlight layer

--- a/client/src/components/watershed/Watershed.vue
+++ b/client/src/components/watershed/Watershed.vue
@@ -213,6 +213,9 @@ const updateFilters = (newFilters) => {
     });
 };
 
+/**
+ * fetches only those uniquely-id'd features within the current map view
+ */
 const getVisibleLicenses = () => {
     const queriedFeatures = map.value.queryRenderedFeatures({
         layers: ["point-layer"],


### PR DESCRIPTION
# Description
This addition adds a listing of the currently displayed points from the map in the right-hand sidebar. This exists for the Watershed view and improves on the current implementation by adding virtual scroll to reduce the load on rendering a large number of points in a list. Additionally, the sidebar point list was given some user interaction.

## Types of changes
- added listing of points to the streamflow view
- modified current MapFilters point list to use virtual scroll

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments

The hover event listener is merely a placeholder. The functionality may not be desired. 
<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->