### PR TITLE
Configure PV/PVC, logging, on OKD cluster

### DIFF
--- a/airflow/pod_templates/simple_task_template.yaml
+++ b/airflow/pod_templates/simple_task_template.yaml
@@ -72,17 +72,11 @@ spec:
   tolerations: []
   topologySpreadConstraints: []
   serviceAccountName: airflow-worker
-  volumes:
-    - emptyDir: {}
-      name: logs
-    - configMap:
-        name: airflow-config
-      name: config
   # Once a PVC successfully created:
-  # volumes:
-  #   - name: logs
-  #     persistentVolumeClaim:
-  #       claimName: airflow-logs
-  #   - name: config
-  #     configMap:
-  #       name: airflow-config
+  volumes:
+    - name: logs
+      persistentVolumeClaim:
+        claimName: airflow-logs
+    - name: config
+      configMap:
+        name: airflow-config

--- a/charts/airflow/README.md
+++ b/charts/airflow/README.md
@@ -33,3 +33,5 @@ helm upgrade --install airflow apache-airflow/airflow   --namespace bcwat   --cr
 This creates a Helm release from the official `apache-airflow/airflow` Chart, where we overwrite the base airflow image with our custom airflow image.
 
 This assumes that docker images exist for airflow and are present on the OKD internal registry.
+
+Furthermore, this requires a Persistent Volume and Persistent Volume Claim to be initialized for logs to be collected from running pods, and be retained and able to be viewed on the webserver. To accomplish this, check the `nfs-server/README.md`

--- a/charts/airflow/values.base.yaml
+++ b/charts/airflow/values.base.yaml
@@ -22,18 +22,9 @@ dags:
 
 logs:
   persistence:
-    enabled: false
-    # enabled: true
-    # https://github.com/airflow-helm/charts/blob/main/charts/airflow/docs/faq/monitoring/log-persistence.md
-    # Accessmode Defaults to "ReadWriteMany"
-    # Requires Config of:
-    # - Persistent Volume
-    # - Persistent Volume Claim
-    # - Storage Class
-    # Look into https://github.com/kubernetes-csi/csi-driver-nfs/tree/master/charts/latest:
-    # This will initialize an NFS Server in which our Persistent Volumes will be created
-    # Can automatically create a storageClass, assign as default, and PVC will use that storage class
-    # Automatically creates a Persistent Volume on Disk when PVC created
+    # Enable persistent volume for storing logs
+    enabled: true
+    existingClaim: airflow-logs
 
 # Airflow database config
 # Requires Airflow-metadata secret to have been created, pointing to the external database handling airflow metadata info

--- a/charts/app/Chart.yaml
+++ b/charts/app/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: quickstart-openshift
+name: BC Water Allocation Tool
 description: Helm Chart for deploying the Client & API of the BC Water Tool Consolidation
 icon: https://www.nicepng.com/png/detail/521-5211827_bc-icon-british-columbia-government-logo.png
 type: application

--- a/charts/nfs-server/README.md
+++ b/charts/nfs-server/README.md
@@ -1,0 +1,17 @@
+# Persistent Volume/Persistent Volume Claim
+
+This requires an NFS Server to be configured.
+
+On the Foundry OnPrem server, we have an NFS Server mounted on `controlplane0`.
+
+To ensure logs persist even when a Pod is evicted, this is required.
+
+Pods also will not get scheduled properly via the scheduler, due to our `pod_templates`  expecting a volume to exist titled `airflow-logs`.
+
+Therefore, these must be configured prior to deploying on Openshift.
+
+To create PV/PVC onPrem:
+
+```bash
+oc apply -f okd/
+```

--- a/charts/nfs-server/okd/persistentvolume.yaml
+++ b/charts/nfs-server/okd/persistentvolume.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: airflow-logs
+  namespace: bcwat
+spec:
+  capacity:
+    storage: 10Gi
+  accessModes:
+    - ReadWriteMany
+  nfs:
+    path: /var/mnt/md0
+    server: controlplane0
+  persistentVolumeReclaimPolicy: Retain

--- a/charts/nfs-server/okd/persistentvolumeclaim.yaml
+++ b/charts/nfs-server/okd/persistentvolumeclaim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: airflow-logs
+  namespace: bcwat
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 10Gi
+  volumeName: airflow-logs
+  storageClassName: ""


### PR DESCRIPTION
# Description

PVC Created for persistent logging of Airflow Pods.

## Types of changes

Configured for Foundry OKD, some changes will need to be initialized to work on BCGov openshift. Namely, location of NFS Server.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have added necessary documentation (if appropriate)

## Further comments

This is quite simple. I have updated the READMEs, let me know if not suitable. Basically, prior to this being installed, it requires a DB to be created for Airflow Metadata, as well as a PV/PVC to be created called airflow-logs. Once this is done, everything should be smooth.