### PR TITLE
Bcwat 52 monthly mean flow

### DIFF
--- a/client/src/components/streamflow/MonthlyMeanFlow.vue
+++ b/client/src/components/streamflow/MonthlyMeanFlow.vue
@@ -59,13 +59,14 @@ const setTableData = () => {
     // set the rows
     tableRows.value = [];
 
+
+    const foundVars = [
+        { name: 'Mean', type: 'avg', found: false }, 
+        { name: 'Maximum', type: 'max', found: false }, 
+        { name: 'Minimum', type: 'min', found: false }, 
+    ];
     // populate rows with mean, max, min data
     tableData.value.monthly_mean_flow.current.forEach(el => {
-        const foundVars = [
-            { name: 'Mean', type: 'avg', found: false }, 
-            { name: 'Maximum', type: 'max', found: false }, 
-            { name: 'Minimum', type: 'min', found: false }, 
-        ];
         foundVars.forEach(type => {
             type.found = tableRows.value.find(row => row.year === type.name);
             if(!type.found){

--- a/client/src/components/streamflow/MonthlyMeanFlow.vue
+++ b/client/src/components/streamflow/MonthlyMeanFlow.vue
@@ -1,7 +1,56 @@
 <template>
     <h3>Monthly Mean Flow</h3>
+    <div>
+        {{ monthlyMeanFlow.monthly_mean_flow }}
+    </div>
+    <q-table
+        v-if="tableCols.length > 0 && tableRows.length > 0 && !loading"
+        flat bordered
+        title="Treats"
+        dense
+        :rows="tableRows"
+        :columns="tableCols"
+        row-key="name"
+    />
 </template>
 
 <script setup>
-import * as d3 from "d3";
+import monthlyMeanFlow from '@/constants/monthlyMeanFlow.json';
+import { monthAbbrList } from '@/constants/dateHelpers.js';
+import { onMounted, ref } from 'vue';
+
+const loading = ref(false);
+const tableData = ref();
+const tableCols = ref([])
+
+onMounted(async () => {
+    loading.value = true;
+    await getTableData();
+    setTableData();
+    loading.value = false;
+})
+
+const setTableData = () => {
+    // set the columns
+    tableCols.value = monthAbbrList.map((month, idx) => {
+        return {
+            name: idx + 1,
+            label: month,
+            field: idx + 1,
+        }
+    })
+
+    tableData.value.monthly_mean_flow.current.map((el, idx) => {
+        return {
+            name: 
+        }
+    })
+}
+
+const getTableData = () => {
+    // TODO add API fetch call here for the monthly mean flow data
+    tableData.value = monthlyMeanFlow;
+}
+
+
 </script>

--- a/client/src/components/streamflow/MonthlyMeanFlow.vue
+++ b/client/src/components/streamflow/MonthlyMeanFlow.vue
@@ -58,15 +58,38 @@ const setTableData = () => {
 
     // set the rows
     tableRows.value = [];
+
+    // populate rows with mean, max, min data
+    tableData.value.monthly_mean_flow.current.forEach(el => {
+        const foundVars = [
+            { name: 'Mean', type: 'avg', found: false }, 
+            { name: 'Maximum', type: 'max', found: false }, 
+            { name: 'Minimum', type: 'min', found: false }, 
+        ];
+        foundVars.forEach(type => {
+            type.found = tableRows.value.find(row => row.year === type.name);
+            if(!type.found){
+                tableRows.value.push({
+                    year: type.name,
+                    [monthAbbrList[el.m - 1]]: el[type.type] ? el[type.type] : '-',
+                });
+            } else {
+                type.found[monthAbbrList[el.m - 1]] = el[type.type] ? el[type.type] : '-'
+            }
+        })
+
+    })
+
+    // populate rows with yearly data
     tableData.value.monthly_mean_flow.yearly.forEach(el => {
-        const foundRow = tableRows.value.find(row => row.year === el.year)
+        const foundRow = tableRows.value.find(row => row.year === el.year);
         if(!foundRow){
             tableRows.value.push({
                 year: el.year,
                 [monthAbbrList[el.m - 1]]: el.v ? el.v : '-',
-            })
+            });
         } else {
-            foundRow[monthAbbrList[el.m - 1]] = el.v ? el.v : '-'
+            foundRow[monthAbbrList[el.m - 1]] = el.v ? el.v : '-';
         }
     })
 }

--- a/client/src/constants/monthlyMeanFlow.json
+++ b/client/src/constants/monthlyMeanFlow.json
@@ -1,0 +1,177 @@
+{
+    "monthly_mean_flow": {
+        "current": [
+            {
+                "m": 1,
+                "avg": null,
+                "max": null,
+                "min": null
+            },
+            {
+                "m": 2,
+                "avg": null,
+                "max": null,
+                "min": null
+            },
+            {
+                "m": 3,
+                "avg": null,
+                "max": null,
+                "min": null
+            },
+            {
+                "m": 4,
+                "avg": null,
+                "max": null,
+                "min": null
+            },
+            {
+                "m": 5,
+                "avg": null,
+                "max": null,
+                "min": null
+            },
+            {
+                "m": 6,
+                "avg": null,
+                "max": null,
+                "min": null
+            },
+            {
+                "m": 7,
+                "avg": null,
+                "max": null,
+                "min": null
+            },
+            {
+                "m": 8,
+                "avg": null,
+                "max": null,
+                "min": null
+            },
+            {
+                "m": 9,
+                "avg": 0.397,
+                "max": 0.397,
+                "min": 0.397
+            },
+            {
+                "m": 10,
+                "avg": 0.33,
+                "max": 0.33,
+                "min": 0.33
+            },
+            {
+                "m": 11,
+                "avg": null,
+                "max": null,
+                "min": null
+            },
+            {
+                "m": 12,
+                "avg": null,
+                "max": null,
+                "min": null
+            }
+        ],
+        "yearly": [
+            {
+                "year": 2023,
+                "m": 1,
+                "v": null,
+                "days": null,
+                "qa": null,
+                "full_month": null
+            },
+            {
+                "year": 2023,
+                "m": 2,
+                "v": null,
+                "days": null,
+                "qa": null,
+                "full_month": null
+            },
+            {
+                "year": 2023,
+                "m": 3,
+                "v": null,
+                "days": null,
+                "qa": null,
+                "full_month": null
+            },
+            {
+                "year": 2023,
+                "m": 4,
+                "v": null,
+                "days": null,
+                "qa": null,
+                "full_month": null
+            },
+            {
+                "year": 2023,
+                "m": 5,
+                "v": null,
+                "days": null,
+                "qa": null,
+                "full_month": null
+            },
+            {
+                "year": 2023,
+                "m": 6,
+                "v": null,
+                "days": null,
+                "qa": null,
+                "full_month": null
+            },
+            {
+                "year": 2023,
+                "m": 7,
+                "v": null,
+                "days": null,
+                "qa": null,
+                "full_month": null
+            },
+            {
+                "year": 2023,
+                "m": 8,
+                "v": 0.38,
+                "days": "4",
+                "qa": true,
+                "full_month": false
+            },
+            {
+                "year": 2023,
+                "m": 9,
+                "v": 0.397,
+                "days": "30",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2023,
+                "m": 10,
+                "v": 0.33,
+                "days": "31",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2023,
+                "m": 11,
+                "v": 0.332,
+                "days": "17",
+                "qa": true,
+                "full_month": false
+            },
+            {
+                "year": 2023,
+                "m": 12,
+                "v": null,
+                "days": null,
+                "qa": null,
+                "full_month": null
+            }
+        ],
+        "__typename": "StationGraphData"
+    }
+}

--- a/client/src/constants/monthlyMeanFlow.json
+++ b/client/src/constants/monthlyMeanFlow.json
@@ -21,45 +21,45 @@
             },
             {
                 "m": 4,
-                "avg": null,
-                "max": null,
-                "min": null
+                "avg": 16.716,
+                "max": 23.174,
+                "min": 10.258
             },
             {
                 "m": 5,
-                "avg": null,
-                "max": null,
-                "min": null
+                "avg": 34.138,
+                "max": 39.081,
+                "min": 29.194
             },
             {
                 "m": 6,
-                "avg": null,
-                "max": null,
-                "min": null
+                "avg": 16.253,
+                "max": 20.828,
+                "min": 11.678
             },
             {
                 "m": 7,
-                "avg": null,
-                "max": null,
-                "min": null
+                "avg": 3.167,
+                "max": 5.058,
+                "min": 1.276
             },
             {
                 "m": 8,
-                "avg": null,
-                "max": null,
-                "min": null
+                "avg": 1.522,
+                "max": 1.781,
+                "min": 1.264
             },
             {
                 "m": 9,
-                "avg": 0.397,
-                "max": 0.397,
-                "min": 0.397
+                "avg": 1.684,
+                "max": 2.115,
+                "min": 1.253
             },
             {
                 "m": 10,
-                "avg": 0.33,
-                "max": 0.33,
-                "min": 0.33
+                "avg": 2.471,
+                "max": 3.529,
+                "min": 1.413
             },
             {
                 "m": 11,
@@ -76,7 +76,7 @@
         ],
         "yearly": [
             {
-                "year": 2023,
+                "year": 2016,
                 "m": 1,
                 "v": null,
                 "days": null,
@@ -84,7 +84,7 @@
                 "full_month": null
             },
             {
-                "year": 2023,
+                "year": 2016,
                 "m": 2,
                 "v": null,
                 "days": null,
@@ -92,7 +92,7 @@
                 "full_month": null
             },
             {
-                "year": 2023,
+                "year": 2016,
                 "m": 3,
                 "v": null,
                 "days": null,
@@ -100,76 +100,172 @@
                 "full_month": null
             },
             {
-                "year": 2023,
+                "year": 2016,
                 "m": 4,
-                "v": null,
-                "days": null,
-                "qa": null,
-                "full_month": null
-            },
-            {
-                "year": 2023,
-                "m": 5,
-                "v": null,
-                "days": null,
-                "qa": null,
-                "full_month": null
-            },
-            {
-                "year": 2023,
-                "m": 6,
-                "v": null,
-                "days": null,
-                "qa": null,
-                "full_month": null
-            },
-            {
-                "year": 2023,
-                "m": 7,
-                "v": null,
-                "days": null,
-                "qa": null,
-                "full_month": null
-            },
-            {
-                "year": 2023,
-                "m": 8,
-                "v": 0.38,
-                "days": "4",
-                "qa": true,
-                "full_month": false
-            },
-            {
-                "year": 2023,
-                "m": 9,
-                "v": 0.397,
+                "v": 23.174,
                 "days": "30",
                 "qa": true,
                 "full_month": true
             },
             {
-                "year": 2023,
-                "m": 10,
-                "v": 0.33,
+                "year": 2016,
+                "m": 5,
+                "v": 29.194,
                 "days": "31",
                 "qa": true,
                 "full_month": true
             },
             {
-                "year": 2023,
+                "year": 2016,
+                "m": 6,
+                "v": 11.678,
+                "days": "30",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2016,
+                "m": 7,
+                "v": 5.058,
+                "days": "31",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2016,
+                "m": 8,
+                "v": 1.781,
+                "days": "31",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2016,
+                "m": 9,
+                "v": 2.115,
+                "days": "30",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2016,
+                "m": 10,
+                "v": 3.529,
+                "days": "31",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2016,
                 "m": 11,
-                "v": 0.332,
-                "days": "17",
+                "v": 6.203,
+                "days": "13",
                 "qa": true,
                 "full_month": false
             },
             {
-                "year": 2023,
+                "year": 2016,
                 "m": 12,
                 "v": null,
                 "days": null,
                 "qa": null,
                 "full_month": null
+            },
+            {
+                "year": 2017,
+                "m": 1,
+                "v": null,
+                "days": null,
+                "qa": null,
+                "full_month": null
+            },
+            {
+                "year": 2017,
+                "m": 2,
+                "v": null,
+                "days": null,
+                "qa": null,
+                "full_month": null
+            },
+            {
+                "year": 2017,
+                "m": 3,
+                "v": 2.353,
+                "days": "19",
+                "qa": true,
+                "full_month": false
+            },
+            {
+                "year": 2017,
+                "m": 4,
+                "v": 10.258,
+                "days": "30",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2017,
+                "m": 5,
+                "v": 39.081,
+                "days": "31",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2017,
+                "m": 6,
+                "v": 20.828,
+                "days": "30",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2017,
+                "m": 7,
+                "v": 1.276,
+                "days": "31",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2017,
+                "m": 8,
+                "v": 1.264,
+                "days": "31",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2017,
+                "m": 9,
+                "v": 1.253,
+                "days": "30",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2017,
+                "m": 10,
+                "v": 1.413,
+                "days": "31",
+                "qa": true,
+                "full_month": true
+            },
+            {
+                "year": 2017,
+                "m": 11,
+                "v": 1.573,
+                "days": "23",
+                "qa": true,
+                "full_month": false
+            },
+            {
+                "year": 2017,
+                "m": 12,
+                "v": 1.353,
+                "days": "4",
+                "qa": true,
+                "full_month": false
             }
         ],
         "__typename": "StationGraphData"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Including the Monthly Mean Flow table in the streamflow report popup. This includes a table with gradient shading based on the values for each row for the indicated years, as well as for minimum, maximum, and mean rows. 

- introduced a new table
- added color gradient handling within the table
- added a fixture data file for monthly mean flow data

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [ ] I have checked that unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have added necessary documentation (if appropriate)

## Further comments
This table only uses fixture data for now. In the future, changes will be made to use an API call. The `getTableData` function has been set up to serve this purpose in the future, so all that needs to be done is update the function to await the API response. 

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->