### PR TITLE
Fixed Scraper errors 

### DIFF
--- a/airflow/etl_pipelines/scrapers/DataBcPipeline/licences/water_approval_points.py
+++ b/airflow/etl_pipelines/scrapers/DataBcPipeline/licences/water_approval_points.py
@@ -185,10 +185,10 @@ class WaterApprovalPointsPipeline(DataBcPipeline):
 
         # Add the resulting DF's to the transformed data attribute
         if not new_approvals.is_empty():
-            self._EtlPipeline__transformed_data["new_approval"] = [new_approvals, ["bc_wls_water_approval_id"], True]
+            self._EtlPipeline__transformed_data["new_approval"] = {"df": new_approvals, "pkey": ["bc_wls_water_approval_id"], "truncate": True}
 
         if not deanna_in_management_area.is_empty():
-            self._EtlPipeline__transformed_data["deanna_in_management_area"] = [deanna_in_management_area, ["bc_wls_water_approval_id"], False]
+            self._EtlPipeline__transformed_data["deanna_in_management_area"] = {"df": deanna_in_management_area, "pkey": ["bc_wls_water_approval_id"], "truncate": False}
 
         logger.info(f"The old approvals table had {current_approvals_shape[0]} rows in it. The new approval tables has {new_approvals.shape[0] + deanna_in_management_area.shape[0]} rows in it.")
 

--- a/airflow/etl_pipelines/scrapers/DataBcPipeline/licences/water_rights_licences_public.py
+++ b/airflow/etl_pipelines/scrapers/DataBcPipeline/licences/water_rights_licences_public.py
@@ -282,7 +282,7 @@ class WaterRightsLicencesPublicPipeline(DataBcPipeline):
             if not appurtenant_land.is_empty():
                 logger.warning(APPURTENTANT_LAND_REVIEW_MESSAGE)
 
-                self._EtlPipeline__transformed_data["appurtenant_land"] = [appurtenant_land, ["licence_no"], False]
+                self._EtlPipeline__transformed_data["appurtenant_land"] = {"df": appurtenant_land, "pkey": ["licence_no"], "truncate": False}
                 # TODO: If sending emails, do it here and send an email instead of logging an Warning.
 
             # Check if there are any lincence_nos in the bc_app_land that have null values in the appurtenant_land column.
@@ -292,7 +292,7 @@ class WaterRightsLicencesPublicPipeline(DataBcPipeline):
                 # TODO: If sending emails, do it here and send an email instead of logging an Warning.
 
             if not new_rights_joined.limit(1).collect().is_empty():
-                self._EtlPipeline__transformed_data[self.databc_layer_name] = [new_rights_joined.collect(), ["wrlp_id"], True]
+                self._EtlPipeline__transformed_data[self.databc_layer_name] = {"df": new_rights_joined.collect(), "pkey": ["wrlp_id"], "truncate": True}
 
         except Exception as e:
             logger.error(f"Transformation for {self.name} failed! {e}")

--- a/airflow/etl_pipelines/scrapers/EtlPipeline.py
+++ b/airflow/etl_pipelines/scrapers/EtlPipeline.py
@@ -76,14 +76,14 @@ class EtlPipeline(ABC):
 
         for key in keys:
             # Check that the data to be inserted is not empty, if so, raise warning.
-            if transformed_data[key][0].is_empty():
+            if transformed_data[key]["df"].is_empty():
                 logger.warning(f"The data to be inserted into the table {self.destination_tables[key]} is empty! Skipping this table and moving on.")
                 # TODO: Implement email to notify that this happened.
                 continue
 
             logger.debug(f"Loading data into the table {self.destination_tables[key]}")
             try:
-                self._load_data_into_tables(insert_tablename=self.destination_tables[key], data=transformed_data[key][0], pkey=transformed_data[key][1], truncate=transformed_data[key][2])
+                self._load_data_into_tables(insert_tablename=self.destination_tables[key], data=transformed_data[key]["df"], pkey=transformed_data[key]["pkey"], truncate=transformed_data[key]["truncate"])
             except Exception as e:
                 logger.error(f"Error loading data into the table {self.destination_tables[key]}")
                 raise RuntimeError(f"Error loading data into the table {self.destination_tables[key]}. Error: {e}")

--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/StationObservationPipeline.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/StationObservationPipeline.py
@@ -645,15 +645,15 @@ class StationObservationPipeline(EtlPipeline):
                 None
         """
         logger.info("Post Processing: Checking if the station_year table is up to date.")
-        station_data = self._EtlPipeline__transformed_data
+        station_data = self.get_transformed_data()
 
         station = pl.DataFrame()
         # Get all station_id that have new data inserted into it.
         for key in station_data.keys():
             if not station.is_empty():
-                station = pl.concat([station, station_data[key][0].select("station_id").unique()])
+                station = pl.concat([station, station_data[key]["df"].select("station_id").unique()])
             else:
-                station = station_data[key][0].select("station_id").unique()
+                station = station_data[key]["df"].select("station_id").unique()
 
         # Drop duplicate rows and add column year with current year
         station =(
@@ -697,13 +697,13 @@ class StationObservationPipeline(EtlPipeline):
             None
         """
         logger.info("Checking if the number of stations scraped is acceptable.")
-        transformed_data = self._EtlPipeline__transformed_data
+        transformed_data = self.get_transformed_data()
         total_scrape_station_count = self.station_list.collect().shape[0]
 
         station_count_with_data = []
         # Get number of unique station_ids in each dataframe in dictionary
         for key in transformed_data:
-            ratio = transformed_data[key][0].select("station_id").unique().shape[0]/total_scrape_station_count
+            ratio = transformed_data[key]["df"].select("station_id").unique().shape[0]/total_scrape_station_count
             station_count_with_data.append({
                 "key": key,
                 "station_ratio": ratio,

--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/asp.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/asp.py
@@ -182,9 +182,9 @@ class AspPipeline(StationObservationPipeline):
                     ])
 
                 if key in ["SW", "SD"]:
-                    self._EtlPipeline__transformed_data[key] = [df, ["station_id", "datestamp"]]
+                    self._EtlPipeline__transformed_data[key] = {"df": df, "pkey": ["station_id", "datestamp"], "truncate": False}
                 else:
-                    self._EtlPipeline__transformed_data[key] = [df, ["station_id", "datestamp", "variable_id"]]
+                    self._EtlPipeline__transformed_data[key] = {"df": df, "pkey": ["station_id", "datestamp", "variable_id"], "truncate": False}
 
             except Exception as e:
                 logger.error(f"Error when trying to transform the data for {self.name} with key {key}. Error: {e}", exc_info=True)

--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/drive_bc.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/drive_bc.py
@@ -121,7 +121,7 @@ class DriveBcPipeline(StationObservationPipeline):
             raise RuntimeError(f"Error when trying to transform the data for {self.name}. Error: {e}")
 
         # Set private variable to have the transformed data as well as list of primary keys
-        self._EtlPipeline__transformed_data["drive_bc"] = [df, ["station_id", "datetimestamp", "variable_id"]]
+        self._EtlPipeline__transformed_data["drive_bc"] = {"df": df, "pkey": ["station_id", "datetimestamp", "variable_id"], "truncate": False}
 
         logger.info(f"Finished Transforming data for {self.name}")
 

--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/ec_xml.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/ec_xml.py
@@ -160,10 +160,10 @@ class EcXmlPipeline(StationObservationPipeline):
         )
 
         self._EtlPipeline__transformed_data = {
-            "precipitation": [precip_df, ["station_id", "datestamp", "variable_id"]],
-            "temperature": [temperature_df, ["station_id", "datestamp", "variable_id"]],
-            "snow_amount": [snow_df, ["station_id", "datestamp"]],
-            "wind": [wind_df, ["station_id", "datestamp", "variable_id"]]
+            "precipitation": {"df": precip_df, "pkey": ["station_id", "datestamp", "variable_id"], "truncate": False},
+            "temperature": {"df": temperature_df, "pkey": ["station_id", "datestamp", "variable_id"], "truncate": False},
+            "snow_amount": {"df": snow_df, "pkey": ["station_id", "datestamp"], "truncate": False},
+            "wind": {"df": wind_df, "pkey": ["station_id", "datestamp", "variable_id"], "truncate": False}
         }
 
         logger.info(f"Finished Transforming data for {self.name}")

--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/env_aqn.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/env_aqn.py
@@ -143,8 +143,8 @@ class EnvAqnPipeline(StationObservationPipeline):
             raise RuntimeError(f"Error when constructing the insertion table for Precipitation. Error: {e}")
 
         self._EtlPipeline__transformed_data = {
-            "temperature": [df_temp, ["station_id", "datestamp", "variable_id"]],
-            "precipitation": [df_precip, ["station_id", "datestamp", "variable_id"]]
+            "temperature": {"df": df_temp, "pkey": ["station_id", "datestamp", "variable_id"], "truncate": False},
+            "precipitation": {"df": df_precip, "pkey": ["station_id", "datestamp", "variable_id"], "truncate": False}
         }
 
         logger.info(f"Finished Transforming data for {self.name}")

--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/flnro_wmb.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/flnro_wmb.py
@@ -150,8 +150,8 @@ class FlnroWmbPipeline(StationObservationPipeline):
             raise RuntimeError(f"Error when constructing the insertion table for Precipitation. Error: {e}")
 
         self._EtlPipeline__transformed_data = {
-            "temperature": [df_temp, ["station_id", "datestamp", "variable_id"]],
-            "precipitation": [df_precip, ["station_id", "datestamp", "variable_id"]]
+            "temperature": {"df": df_temp, "pkey": ["station_id", "datestamp", "variable_id"], "truncate": False},
+            "precipitation": {"df": df_precip, "pkey": ["station_id", "datestamp", "variable_id"], "truncate": False}
         }
 
         logger.info(f"Finished Transforming data for {self.name}")

--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/msp.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/msp.py
@@ -112,7 +112,7 @@ class MspPipeline(StationObservationPipeline):
                 )
             ).collect()
 
-            self._EtlPipeline__transformed_data["msp"] = [df, ["station_id", "survey_period", "variable_id"]]
+            self._EtlPipeline__transformed_data["msp"] = {"df": df, "pkey": ["station_id", "survey_period", "variable_id"], "truncate": False}
 
         except Exception as e:
             logger.error(f"Error when trying to transform the data for {self.name}. Error: {e}", exc_info=True)

--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/weather_farm_prd.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/climate/weather_farm_prd.py
@@ -186,8 +186,8 @@ class WeatherFarmPrdPipeline(StationObservationPipeline):
         )
 
         self._EtlPipeline__transformed_data = {
-            "temperature": [temp_df, ["station_id", "datestamp", "variable_id"]],
-            "rainfall": [rain_df, ["station_id", "datestamp", "variable_id"]]
+            "temperature": {"df": temp_df, "pkey": ["station_id", "datestamp", "variable_id"], "truncate": False},
+            "rainfall": {"df": rain_df, "pkey": ["station_id", "datestamp", "variable_id"], "truncate": False}
         }
 
         logger.info(f"Finished Transformation for {self.name}")

--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/water/env_hydro.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/water/env_hydro.py
@@ -109,7 +109,7 @@ class EnvHydroPipeline(StationObservationPipeline):
                 ).collect()
 
                 # Assign to private attribute
-                self._EtlPipeline__transformed_data[key] = [df, ["station_id", "datestamp"]]
+                self._EtlPipeline__transformed_data[key] = {"df": df, "pkey": ["station_id", "datestamp"], "truncate": False}
 
             except Exception as e:
                 logger.error(f"Error when trying to transform the downloaded data. Error: {e}", exc_info=True)
@@ -154,7 +154,7 @@ class EnvHydroPipeline(StationObservationPipeline):
         )
 
         try:
-            in_bc = self.check_new_station_in_bc(new_stations.select("original_id", " Longitude", " Latitude").unique())
+            in_bc = self.check_new_station_in_bc(new_stations.select("original_id", "Longitude", "Latitude").unique())
         except Exception as e:
             logger.error("Error when trying to check if new stations are in BC.")
             raise RuntimeError(e)
@@ -196,7 +196,7 @@ class EnvHydroPipeline(StationObservationPipeline):
             new_stations
             .select(
                 "original_id",
-                " Parameter"
+                "Parameter"
             )
             .unique()
             .group_by("original_id")
@@ -228,17 +228,17 @@ class EnvHydroPipeline(StationObservationPipeline):
                     )
                     .then([1,2])
                     .when(
-                        (~pl.col("original_id").is_in(stage_discharge_filter)) & (pl.col(" Parameter") == "Discharge")
+                        (~pl.col("original_id").is_in(stage_discharge_filter)) & (pl.col("Parameter") == "Discharge")
                     )
                     .then([1])
                     .otherwise([2])
             )
             .select(
                 pl.col("original_id"),
-                pl.col(" Location Name").alias("station_name"),
+                pl.col("Location Name").alias("station_name"),
                 pl.col("station_status_id"),
-                pl.col(" Longitude").alias("longitude"),
-                pl.col(" Latitude").alias("latitude"),
+                pl.col("Longitude").alias("longitude"),
+                pl.col("Latitude").alias("latitude"),
                 pl.col("scrape"),
                 pl.col("stream_name"),
                 pl.col("station_description"),
@@ -264,4 +264,3 @@ class EnvHydroPipeline(StationObservationPipeline):
         except Exception as e:
             logger.error(f"Error when trying to insert new stations. Error: {e}")
             raise RuntimeError(e)
-

--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/water/flow_works.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/water/flow_works.py
@@ -283,9 +283,9 @@ class FlowWorksPipeline(StationObservationPipeline):
                     df = pl.concat([df_min, df_avg, df_max]).collect()
 
                 if key in ["discharge", "stage", "swe"]:
-                    self._EtlPipeline__transformed_data[key] = [df, ["station_id", "datestamp"]]
+                    self._EtlPipeline__transformed_data[key] = {"df": df, "pkey": ["station_id", "datestamp"], "truncate": False}
                 else:
-                    self._EtlPipeline__transformed_data[key] = [df, ["station_id", "datestamp", "variable_id"]]
+                    self._EtlPipeline__transformed_data[key] = {"df": df, "pkey": ["station_id", "datestamp", "variable_id"], "truncate": False}
 
 
             except Exception as e:
@@ -667,4 +667,3 @@ class FlowWorksPipeline(StationObservationPipeline):
         except Exception as e:
             logger.error("Error when trying to insert new stations into the database.")
             raise RuntimeError(e)
-

--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/water/gw_moe.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/water/gw_moe.py
@@ -107,7 +107,7 @@ class GwMoePipeline(StationObservationPipeline):
         logger.info(f"""NOTE: Out of the {total_station_with_data} stations that returned a 200 response and was not emtpy csv files only {df.n_unique("station_id")} stations had recent data (within the last 2 days)""")
 
         self._EtlPipeline__transformed_data = {
-            "gw_level" : [df, ["station_id", "datestamp"]]
+            "gw_level" : {"df": df, "pkey": ["station_id", "datestamp"], "truncate": False}
         }
 
         logger.info(f"Transformation complete for Groundwater Level")

--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/water/wsc_hydrometric.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/water/wsc_hydrometric.py
@@ -118,8 +118,8 @@ class WscHydrometricPipeline(StationObservationPipeline):
 
         # Set the transformed data
         self._EtlPipeline__transformed_data = {
-            "level": [level_df, ["station_id", "datestamp"]],
-            "discharge": [discharge_df, ["station_id", "datestamp"]]
+            "level": {"df": level_df, "pkey": ["station_id", "datestamp"], "truncate": False},
+            "discharge": {"df": discharge_df, "pkey": ["station_id", "datestamp"], "truncate": False}
         }
 
         logger.info(f"Transformation complete for Level and Discharge data")

--- a/airflow/etl_pipelines/tests/test_constants/test_wsc_hydrometric_constants.py
+++ b/airflow/etl_pipelines/tests/test_constants/test_wsc_hydrometric_constants.py
@@ -3,7 +3,7 @@ from etl_pipelines.utils.constants import WSC_DTYPE_SCHEMA
 
 transform_case_2 = pl.LazyFrame(
     {
-        " ID": ["01AB001", "01AB002"],
+        "ID": ["01AB001", "01AB002"],
         "Date": ["2025-04-16T00:00:00-08:00", "2025-04-16T00:00:00-08:00"],
         "Water Level / Niveau d'eau (m)": [1.0, 2.0],
         "Discharge / Débit (cms)": [1.0, 2.0]
@@ -12,7 +12,7 @@ transform_case_2 = pl.LazyFrame(
 
 transform_case_3 = pl.LazyFrame(
     {
-        " ID": ["01AB001", "01AB001", "01AB001", "01AB001", "01AB001", "01AB002", "01AB002", "01AB002", "01AB002", "01AB002"],
+        "ID": ["01AB001", "01AB001", "01AB001", "01AB001", "01AB001", "01AB002", "01AB002", "01AB002", "01AB002", "01AB002"],
         "Water Level / Niveau d'eau (m)": [1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10],
         "Discharge / Débit (cms)": [1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10]
     }
@@ -20,7 +20,7 @@ transform_case_3 = pl.LazyFrame(
 
 transform_case_4 = pl.LazyFrame(
     {
-        " ID": ["01AB001", "01AB001", "01AB001", "01AB001", "01AB001", "01AB002", "01AB002", "01AB002", "01AB002", "01AB002"],
+        "ID": ["01AB001", "01AB001", "01AB001", "01AB001", "01AB001", "01AB002", "01AB002", "01AB002", "01AB002", "01AB002"],
         "Date": ["2025-04-16T00:00:00-08:00", "2025-04-16T06:00:00-08:00", "2025-04-16T12:00:00-08:00", "2025-04-16T18:00:00-08:00", "2025-04-17T00:00:00-08:00", "2025-04-16T00:00:00-08:00", "2025-04-16T06:00:00-08:00", "2025-04-16T12:00:00-08:00", "2025-04-16T18:00:00-08:00", "2025-04-17T00:00:00-08:00"],
         "Water Level / Niveau d'eau (m)": [1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10],
         "Discharge / Débit (cms)": [1.0, 2.0, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -29,7 +29,7 @@ transform_case_4 = pl.LazyFrame(
 
 transform_case_5 = pl.LazyFrame(
     {
-        " ID": ["01AB001", "01AB001", "01AB001", "01AB001", "01AB001", "01AB002", "01AB002", "01AB002", "01AB002", "01AB002"],
+        "ID": ["01AB001", "01AB001", "01AB001", "01AB001", "01AB001", "01AB002", "01AB002", "01AB002", "01AB002", "01AB002"],
         "Date": ["2025-04-16T00:00:00-08:00", "2025-04-16T06:00:00-08:00", "2025-04-16T12:00:00-08:00", "2025-04-16T18:00:00-08:00", "2025-04-17T00:00:00-08:00", "2025-04-16T00:00:00-08:00", "2025-04-16T06:00:00-08:00", "2025-04-16T12:00:00-08:00", "2025-04-16T18:00:00-08:00", "2025-04-17T00:00:00-08:00"],
         "Water Level / Niveau d'eau (m)": [1.0, 2.0, 3, 4, 2.5, 4, 1, None, None, None],
         "Discharge / Débit (cms)": [None, None, None, None, 5, 6, 3, None, 6, None]
@@ -46,7 +46,7 @@ transform_case_station_id = pl.LazyFrame(
 
 validate_data_case_2 = pl.LazyFrame(
     {
-        " ID": ["01AB001"],
+        "ID": ["01AB001"],
         "DateTime": ["2025-04-16T00:00:00-08:00"],
         "Water Level / Niveau d'eau (m)": [1.001],
         "Grade": [None],
@@ -61,7 +61,7 @@ validate_data_case_2 = pl.LazyFrame(
 
 validate_data_case_3 = pl.LazyFrame(
     {
-        " ID": ["01AB001"],
+        "ID": ["01AB001"],
         "Date": ["2025-04-16T00:00:00-08:00"],
         "Water Level / Niveau d'eau (m)": [1.001],
         "Grade": [1],
@@ -76,7 +76,7 @@ validate_data_case_3 = pl.LazyFrame(
 
 validate_data_case_4 = pl.LazyFrame(
     {
-        " ID": ["01AB001"],
+        "ID": ["01AB001"],
         "Date": ["2025-04-16T00:00:00-08:00"],
         "Water Level / Niveau d'eau (m)": [1.001],
         "Grade": [""],
@@ -87,6 +87,6 @@ validate_data_case_4 = pl.LazyFrame(
         "Symbol / Symbole_duplicated_0": [""],
         "QA/QC_duplicated_0": [0]
     },
-    schema_overrides=WSC_DTYPE_SCHEMA,
+    schema_overrides=WSC_DTYPE_SCHEMA["wsc_daily_hydrometric.csv"],
     strict=False
 )

--- a/airflow/etl_pipelines/tests/test_wsc_hydrometric.py
+++ b/airflow/etl_pipelines/tests/test_wsc_hydrometric.py
@@ -21,13 +21,13 @@ import pytest
 import numpy as np
 import pendulum
 
-@freeze_time("2025-04-16 08:00:00")
+@freeze_time("2025-04-16 00:00:00 PST")
 @patch("etl_pipelines.scrapers.StationObservationPipeline.StationObservationPipeline.StationObservationPipeline.get_station_list")
 def test_initialization(mock_get_station_list):
     # This mock happens to ensure that the database is not accessed while testing.
     # The function get_station_list is not unique to this pipeline, so it is mocked.
     mock_get_station_list.return_value = None
-    
+
     # Importing the class has to happen after the patch, or else the get_station_list will be called before it gets patched.
     from etl_pipelines.scrapers.StationObservationPipeline.water.wsc_hydrometric import WscHydrometricPipeline
     pipeline = WscHydrometricPipeline(db_conn="FakeDBConnection", date_now=pendulum.now("UTC"))
@@ -37,9 +37,9 @@ def test_initialization(mock_get_station_list):
     assert pipeline.station_list == None
 
     assert pipeline.source_url == {"wsc_daily_hydrometric.csv": WSC_URL.format("20250416")}
-    
-    assert pipeline.end_date == pendulum.now("UTC")
-    assert pipeline.start_date == pendulum.now("UTC").subtract(days=2)
+
+    assert pipeline.end_date == pendulum.now("America/Vancouver")
+    assert pipeline.start_date == pendulum.now("America/Vancouver").subtract(days=2)
 
     # Assert Initialization Attributes for parent class StationObservationPipeline
     assert not pipeline.go_through_all_stations
@@ -48,7 +48,7 @@ def test_initialization(mock_get_station_list):
     assert pipeline.name == WSC_NAME
     assert pipeline.destination_tables == WSC_DESTINATION_TABLES
     assert pipeline._EtlPipeline__downloaded_data == {}
-    assert pipeline._EtlPipeline__transformed_data is None
+    assert pipeline._EtlPipeline__transformed_data == {}
 
 @patch("etl_pipelines.scrapers.StationObservationPipeline.StationObservationPipeline.StationObservationPipeline.get_station_list")
 @freeze_time("2025-04-16 08:00:00", tz_offset=-8)
@@ -67,7 +67,7 @@ def test_transform_data(mock_get_station_list):
 
     with pytest.raises(KeyError, match=".*get the downloaded data.*"):
         pipeline.transform_data()
-    
+
     # Case 3: Correct filename and download but common transformations fail due to missing column
     pipeline.station_list = transform_case_station_id
     pipeline._EtlPipeline__downloaded_data["wsc_daily_hydrometric.csv"] =  transform_case_3
@@ -90,8 +90,8 @@ def test_transform_data(mock_get_station_list):
 
     pipeline.transform_data()
 
-    level_data = pipeline._EtlPipeline__transformed_data["level"][0].sort(["station_id", "datestamp"])
-    discharge_data = pipeline._EtlPipeline__transformed_data["discharge"][0].sort(["station_id", "datestamp"])
+    level_data = pipeline._EtlPipeline__transformed_data["level"]["df"].sort(["station_id", "datestamp"])
+    discharge_data = pipeline._EtlPipeline__transformed_data["discharge"]["df"].sort(["station_id", "datestamp"])
 
 
     ## Check column names and dtypes
@@ -119,8 +119,8 @@ def test_transform_data(mock_get_station_list):
     pipeline._EtlPipeline__downloaded_data["wsc_daily_hydrometric.csv"] = transform_case_4
 
     pipeline.transform_data()
-    level_data = pipeline._EtlPipeline__transformed_data["level"][0].sort(["station_id", "datestamp"])
-    discharge_data = pipeline._EtlPipeline__transformed_data["discharge"][0].sort(["station_id", "datestamp"])
+    level_data = pipeline._EtlPipeline__transformed_data["level"]["df"].sort(["station_id", "datestamp"])
+    discharge_data = pipeline._EtlPipeline__transformed_data["discharge"]["df"].sort(["station_id", "datestamp"])
 
     ## Check column names and dtypes
     level_columns = level_data.columns
@@ -170,18 +170,18 @@ def test_validate_downloaded_data(mock_get_station_list):
         pipeline.validate_downloaded_data()
 
     # Case 2: Data Downloaded but wrong columns
-    pipeline._EtlPipeline__downloaded_data["in_key"] = validate_data_case_2
+    pipeline._EtlPipeline__downloaded_data["wsc_daily_hydrometric.csv"] = validate_data_case_2
 
     with pytest.raises(ValueError):
         pipeline.validate_downloaded_data()
 
     # Case 3: Data Downloaded but wrong types
-    pipeline._EtlPipeline__downloaded_data["in_key"] = validate_data_case_3
+    pipeline._EtlPipeline__downloaded_data["wsc_daily_hydrometric.csv"] = validate_data_case_3
 
     with pytest.raises(TypeError):
         pipeline.validate_downloaded_data()
-        
+
     #Case 4: Data Downloaded and correct
-    pipeline._EtlPipeline__downloaded_data["in_key"] = validate_data_case_4
+    pipeline._EtlPipeline__downloaded_data["wsc_daily_hydrometric.csv"] = validate_data_case_4
 
     pipeline.validate_downloaded_data()

--- a/airflow/etl_pipelines/utils/constants.py
+++ b/airflow/etl_pipelines/utils/constants.py
@@ -385,7 +385,7 @@ EC_XML_MIN_RATIO = {
     "snow_amount": 0.5
 }
 
-WEATHER_FARM_PRD_NAME = "BC PEace Agri-Weather Network"
+WEATHER_FARM_PRD_NAME = "BC Peace Agri-Weather Network"
 WEATHER_FARM_PRD_STATION_SOURCE = "weatherfarmprd"
 WEATHER_FARM_PRD_NETWORK_ID = ["30"]
 WEATHER_FARM_PRD_BASE_URL = "http://www.bcpeaceweather.com/api/WeatherStation/GetHistoricalStationData?StartDate={}&EndDate={}&StationId={}&TimeInterval=day"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description
Some of the scrapers have been failing with `index out of range` error. This has been fixed and a better value for the attribute `_EtlPipeline__transformed_data` has been created. It used to be a list consisting of the data, primary keys, and a boolean value indicating whether it should be truncated or not. This has been changed to a dictionary with the following key value pairs:

| Keys | Values |
| --- | --- |
| `"df"` | pl.DataFrame with all data to be inserted|
| `"pkey"` | List of Primary Keys |
| `"truncate"` | Boolean value indicating whether the table should be truncated or not |

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added necessary documentation (if appropriate)