### PR TITLE
RM deploy on PR Open

### DIFF
--- a/.github/workflows/pr-open.yml
+++ b/.github/workflows/pr-open.yml
@@ -1,7 +1,8 @@
 name: PR
 
 on:
-  pull_request:
+  # pull_request:
+  workflow_dispatch:
 
 concurrency:
   # Cancel in progress for PR open and close


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Remove Auto Deploy on PR Creation

## Types of changes

Will be turned on in the future, however we must initialized a dedicated dev database initialized, rather than the DB per PR Open
