### PR TITLE
Lock Chart Verison, Update to python3.12

### DIFF
--- a/.github/workflows/foundry.okd.on-push.application.yaml
+++ b/.github/workflows/foundry.okd.on-push.application.yaml
@@ -160,6 +160,7 @@ jobs:
         run: |
           helm upgrade --install airflow apache-airflow/airflow \
             --namespace bcwat \
+            --version 1.16.0 \
             --atomic \
             -f values.yaml \
             --set images.airflow.tag=${{ needs.bump_version.outputs.version }} \

--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM apache/airflow:2.10.5-python3.10
+FROM apache/airflow:2.10.5-python3.12
 
 USER root
 

--- a/charts/okd/airflow/README.md
+++ b/charts/okd/airflow/README.md
@@ -38,9 +38,17 @@ stringData:
   fernet-key: <fernet-key>
 ```
 
+Locking the Airflow Chart Version to 1.16.0. Corresponds to Airflow Version 2.10.5 (which we use within our Dockerfile)
+
+```bash
+helm search repo apache-airflow/airflow --versions
+NAME                   CHART VERSION APP VERSION DESCRIPTION
+apache-airflow/airflow 1.16.0        2.10.5      The official Helm chart to deploy Apache Airflo...
+```
+
 ```bash
 helm repo add apache-airflow https://airflow.apache.org
-helm upgrade --install airflow apache-airflow/airflow --namespace bcwat --create-namespace -f values.yaml
+helm upgrade --install airflow apache-airflow/airflow --version 1.16.0 --namespace bcwat --create-namespace -f values.yaml
 ```
 
 This creates a Helm release from the official `apache-airflow/airflow` Chart, where we overwrite the base airflow image with our custom airflow image.


### PR DESCRIPTION
# Description

Working on locking airflow version, mitigating against future updates.

## Types of changes

New feature (non-breaking change which adds functionality) 
Documentation (non-breaking change with enhancements to documentation) 

## Further comments

Set Docker Image to use python3.12, lock chart to 1.16.0 for now.

https://helm.sh/docs/helm/helm_install/

Check out the version flag that we are using.

Also, you can validate the latest chart version is 1.16.0: https://artifacthub.io/packages/helm/apache-airflow/airflow