### PR TITLE
Up API Resources, initialize Node Affinity for Worker Pod Templates

### DIFF
--- a/airflow/pod_templates/heavy_task_template.yaml
+++ b/airflow/pod_templates/heavy_task_template.yaml
@@ -104,7 +104,7 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: polars-unsafe # OKD worker0 (should not impact Openshift)
+              - key: polars-unsafe # OKD worker0 (should not impact BC Government Openshift)
                 operator: NotIn
                 values:
                   - "true"

--- a/airflow/pod_templates/heavy_task_template.yaml
+++ b/airflow/pod_templates/heavy_task_template.yaml
@@ -99,3 +99,12 @@ spec:
     - name: data
       persistentVolumeClaim:
         claimName: airflow-data
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: polars-unsafe # OKD worker0 (should not impact Openshift)
+                operator: NotIn
+                values:
+                  - "true"

--- a/airflow/pod_templates/medium_task_template.yaml
+++ b/airflow/pod_templates/medium_task_template.yaml
@@ -98,7 +98,7 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: polars-unsafe # OKD worker0 (should not impact Openshift)
+              - key: polars-unsafe # OKD worker0 (should not impact BC Government Openshift)
                 operator: NotIn
                 values:
                   - "true"

--- a/airflow/pod_templates/medium_task_template.yaml
+++ b/airflow/pod_templates/medium_task_template.yaml
@@ -93,3 +93,12 @@ spec:
     - name: config
       configMap:
         name: airflow-config
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: polars-unsafe # OKD worker0 (should not impact Openshift)
+                operator: NotIn
+                values:
+                  - "true"

--- a/airflow/pod_templates/simple_task_template.yaml
+++ b/airflow/pod_templates/simple_task_template.yaml
@@ -86,7 +86,6 @@ spec:
   tolerations: []
   topologySpreadConstraints: []
   serviceAccountName: airflow-worker
-  # Once a PVC successfully created:
   volumes:
     - name: logs
       persistentVolumeClaim:
@@ -94,3 +93,12 @@ spec:
     - name: config
       configMap:
         name: airflow-config
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: polars-unsafe # OKD worker0 (should not impact Openshift)
+                operator: NotIn
+                values:
+                  - "true"

--- a/airflow/pod_templates/simple_task_template.yaml
+++ b/airflow/pod_templates/simple_task_template.yaml
@@ -98,7 +98,7 @@ spec:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: polars-unsafe # OKD worker0 (should not impact Openshift)
+              - key: polars-unsafe # OKD worker0 (should not impact BC Government Openshift)
                 operator: NotIn
                 values:
                   - "true"

--- a/charts/okd/app/templates/backend/templates/deployment.yaml
+++ b/charts/okd/app/templates/backend/templates/deployment.yaml
@@ -59,8 +59,8 @@ spec:
             - containerPort: 8000
           resources:
             requests:
-              cpu: 100m
-              memory: 150Mi
+              cpu: 500m
+              memory: 1G
             limits:
-              cpu: 100m
-              memory: 150Mi
+              cpu: 500m
+              memory: 1G


### PR DESCRIPTION
# Description

Mitigate against API OOMing (think its OOMing on load of that massive JSON fixture)
Prevent Pods from getting scheduled on worker0 (not polars compatible)

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Further comments

To test this out, we gotta merge in the quarterly hydat branch, and trigger DAG and see what happens!