### PR TITLE
Debugging Airflow Image Issue

### DIFF
--- a/charts/okd/airflow/values.yaml
+++ b/charts/okd/airflow/values.yaml
@@ -50,6 +50,13 @@ images:
 registry:
   secretName: acr-pull-secret
 
+# Prevent Override of Kubernetes Executor Pods
+# We do not want to supply Pull Secrets - they can just use base image.
+config:
+  kubernetes_executor:
+    worker_container_repository: apache/airflow
+    worker_container_tag: "2.10.5"
+
 webserver:
   waitForMigrations:
     enabled: false


### PR DESCRIPTION
# Description

Started Encountering an issue within our Airflow Worker Pods, where they were trying to pull our private image, and rightfully failing.

## Types of changes

Bug fix (non-breaking change which fixes an issue)

## Further comments

Worker Pods were failing immediately for the following reason:

```
status:
  containerStatuses:
    - name: base
      state:
        waiting:
          reason: ImagePullBackOff
          message: 'Back-off pulling image "foundrymainregistry.azurecr.io/bcwat/airflow:3.2.1"'
      lastState: {}
      ready: false
      restartCount: 0
      image: 'foundrymainregistry.azurecr.io/bcwat/airflow:3.2.1'
      imageID: ''
      started: false
 ```

This is odd to me because we explicitly tell the worker pods to just use the base Airflow Image:

```
  containers:
    - name: base
      image: apache/airflow:2.10.5
      imagePullPolicy: IfNotPresent
```

However, my assumption is the interaction between the following blocks are causing for an override:

```
# Images
images:
  airflow:
    repository: ~
    tag: ~
    # Specifying digest takes precedence over tag.
    digest: ~
    pullPolicy: IfNotPresent
  # To avoid images with user code, you can turn this to 'true' and
  # all the 'run-airflow-migrations' and 'wait-for-airflow-migrations' containers/jobs
  # will use the images from 'defaultAirflowRepository:defaultAirflowTag' values
  # to run and wait for DB migrations .
  useDefaultImageForMigration: false
  # timeout (in seconds) for airflow-migrations to complete
  migrationsWaitTimeout: 60
  pod_template:
    # Note that `images.pod_template.repository` and `images.pod_template.tag` parameters
    # can be overridden in `config.kubernetes` section. So for these parameters to have effect
    # `config.kubernetes.worker_container_repository` and `config.kubernetes.worker_container_tag`
    # must be not set .
    repository: ~
    tag: ~
    pullPolicy: IfNotPresent   
 ```
 
 And
 
 ```
   # The `kubernetes` section is deprecated in Airflow >= 2.5.0 due to an airflow.cfg schema change.
  # The `kubernetes` section can be removed once the helm chart no longer supports Airflow < 2.5.0.
  kubernetes:
    namespace: '{{ .Release.Namespace }}'
    # The following `airflow_` entries are for Airflow 1, and can be removed when it is no longer supported.
    airflow_configmap: '{{ include "airflow_config" . }}'
    airflow_local_settings_configmap: '{{ include "airflow_config" . }}'
    pod_template_file: '{{ include "airflow_pod_template_file" . }}/pod_template_file.yaml'
    worker_container_repository: '{{ .Values.images.airflow.repository | default .Values.defaultAirflowRepository }}'
    worker_container_tag: '{{ .Values.images.airflow.tag | default .Values.defaultAirflowTag }}'
    multi_namespace_mode: '{{ ternary "True" "False" .Values.multiNamespaceMode }}'
  # The `kubernetes_executor` section duplicates the `kubernetes` section in Airflow >= 2.5.0 due to an airflow.cfg schema change.
  kubernetes_executor:
    namespace: '{{ .Release.Namespace }}'
    pod_template_file: '{{ include "airflow_pod_template_file" . }}/pod_template_file.yaml'
    worker_container_repository: '{{ .Values.images.airflow.repository | default .Values.defaultAirflowRepository }}'
    worker_container_tag: '{{ .Values.images.airflow.tag | default .Values.defaultAirflowTag }}'
    multi_namespace_mode: '{{ ternary "True" "False" .Values.multiNamespaceMode }}'
```

So, our worker pods were being overwritten with the following (remember the tag is set within the Github Action)

```
images:
  airflow:
    repository: foundrymainregistry.azurecr.io/bcwat/airflow
    tag: latest
    pullPolicy: Always
```

```
- name: Helm Upgrade Airflow
        working-directory: ./charts/okd/airflow
        run: |
          helm upgrade --install airflow apache-airflow/airflow \
            --namespace bcwat \
            --version 1.16.0 \
            --atomic \
            -f values.yaml \
            --set images.airflow.tag=${{ needs.bump_version.outputs.version }} \
            --timeout 15m
```

This is leading to them trying to pull a private image, and failing, because they do not have access.

I am confident this explicit declaration will resolve the issue. 

If you would like to reference the official helm chart where I am pulling these snippets from: 

https://github.com/apache/airflow/blob/main/chart/values.yaml

