### PR TITLE
Hard Set imagePullSecret

### DIFF
--- a/airflow/pod_templates/heavy_task_template.yaml
+++ b/airflow/pod_templates/heavy_task_template.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 300
   initContainers: []
+  imagePullSecrets:
+    - name: acr-pull-secret
   containers:
     - name: base
       image: apache/airflow:2.10.5

--- a/airflow/pod_templates/medium_task_template.yaml
+++ b/airflow/pod_templates/medium_task_template.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 300
   initContainers: []
+  imagePullSecrets:
+    - name: acr-pull-secret
   containers:
     - name: base
       image: apache/airflow:2.10.5

--- a/airflow/pod_templates/simple_task_template.yaml
+++ b/airflow/pod_templates/simple_task_template.yaml
@@ -11,6 +11,8 @@ metadata:
 spec:
   ttlSecondsAfterFinished: 300
   initContainers: []
+  imagePullSecrets:
+    - name: acr-pull-secret
   containers:
     - name: base
       image: apache/airflow:2.10.5

--- a/charts/okd/airflow/values.yaml
+++ b/charts/okd/airflow/values.yaml
@@ -50,13 +50,6 @@ images:
 registry:
   secretName: acr-pull-secret
 
-# Prevent Override of Kubernetes Executor Pods
-# We do not want to supply Pull Secrets - they can just use base image.
-config:
-  kubernetes_executor:
-    worker_container_repository: apache/airflow
-    worker_container_tag: "2.10.5"
-
 webserver:
   waitForMigrations:
     enabled: false


### PR DESCRIPTION
# Description

I guess we do need to pass the acr-pull-secret in - as the image is being overridden, and now the dagbag is no longer populated by the scheduler?

I do not know what changed, but since the last major update, the worker templates were updated use the base image from the images.airflow block. Previously, I used the base airflow image block. Furthermore, the dagbag needs to be included within the image the worker pods use - before hand, it could be separate (I believe it got populated via triggerer/scheduler/webserver)?

I hope this works!

Furthermore, this will need to be revisited once we have it on BCGov Openshift. Because they will not have a pull secret. We will cross the bridge when we come to it.