### PR TITLE
Comment Out Init Containers - Flyway Race Conditions

### DIFF
--- a/charts/okd/app/templates/backend/templates/deployment.yaml
+++ b/charts/okd/app/templates/backend/templates/deployment.yaml
@@ -21,26 +21,26 @@ spec:
       imagePullSecrets:
         - name: {{ .Values.backend.imagePullSecret }}
       {{- end }}
-      initContainers:
-        - name: {{ .Values.backend.name }}-init
-          image: {{ .Values.migrations.image }}
-          imagePullPolicy: Always
-          env:
-          - name: FLYWAY_URL
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.migrations.secret }}
-                key: jdbc-uri
-          - name: FLYWAY_USER
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.migrations.secret }}
-                key: user
-          - name: FLYWAY_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.migrations.secret }}
-                key: password
+      # initContainers:
+      #   - name: {{ .Values.backend.name }}-init
+      #     image: {{ .Values.migrations.image }}
+      #     imagePullPolicy: Always
+      #     env:
+      #     - name: FLYWAY_URL
+      #       valueFrom:
+      #         secretKeyRef:
+      #           name: {{ .Values.migrations.secret }}
+      #           key: jdbc-uri
+      #     - name: FLYWAY_USER
+      #       valueFrom:
+      #         secretKeyRef:
+      #           name: {{ .Values.migrations.secret }}
+      #           key: user
+      #     - name: FLYWAY_PASSWORD
+      #       valueFrom:
+      #         secretKeyRef:
+      #           name: {{ .Values.migrations.secret }}
+      #           key: password
           resources:
             requests:
               cpu: 50m


### PR DESCRIPTION
Getting an issue currently caused by the flyway migrations script - Init Container:

```
oc logs bcwat-api-79f5db546c-6dw5w -c bcwat-api-init
WARNING: Storing migrations in 'sql' is not recommended and default scanning of this location may be deprecated in a future release
A more recent version of Flyway is available. Find out more about Flyway 11.10.2 at https://rd.gt/3rXiSlV

Flyway OSS Edition 11.8.1 by Redgate

See release notes here: https://rd.gt/416ObMi
Database: jdbc:postgresql://bcwat-db-primary.bcwat.svc:5432/bcwat_dev?password=********&user=bcwat-api-admin (PostgreSQL 17.4)
Schema version: 1.0.0

+-----------+---------+----------------------------+------+---------------------+---------+----------+
| Category  | Version | Description                | Type | Installed On        | State   | Undoable |
+-----------+---------+----------------------------+------+---------------------+---------+----------+
| Versioned | 1.0.0   | init postgis               | SQL  | 2025-07-14 20:42:54 | Success | No       |
| Versioned | 1.0.1   | bcwat obs erd diagram      | SQL  |                     | Pending | No       |
| Versioned | 1.0.2   | bcwat watersed erd diagram | SQL  |                     | Pending | No       |
| Versioned | 1.0.3   | bcwat licence erd diagram  | SQL  |                     | Pending | No       |
+-----------+---------+----------------------------+------+---------------------+---------+----------+

Successfully validated 4 migrations (execution time 00:00.009s)
Current version of schema "public": 1.0.0
Migrating schema "public" to version "1.0.1 - bcwat obs erd diagram"
ERROR: Migration of schema "public" to version "1.0.1 - bcwat obs erd diagram" failed! Changes successfully rolled back.
ERROR: Script V1.0.1__bcwat_obs_erd_diagram.sql failed
-----------------------------------------------
SQL State  : 42P06
Error Code : 0
Message    : ERROR: schema "bcwat_obs" already exists
Location   : /flyway/sql/V1.0.1__bcwat_obs_erd_diagram.sql (/flyway/sql/V1.0.1__bcwat_obs_erd_diagram.sql)
Line       : 2
Statement  : Run Flyway with -X option to see the actual statement causing the problem

Caused by: Script V1.0.1__bcwat_obs_erd_diagram.sql failed
```

This is caused by the data model being present on the DB in which flyway is trying to update, and recognizing schemas already exist.

In the future, we should have create if not exists, but for now, commenting this out should be totally suitable.