### PR TITLE
Add Volume for Data where missing

### DIFF
--- a/airflow/pod_templates/okd/medium_task_template.yaml
+++ b/airflow/pod_templates/okd/medium_task_template.yaml
@@ -98,6 +98,9 @@ spec:
     - name: config
       configMap:
         name: airflow-config
+    - name: data
+      persistentVolumeClaim:
+        claimName: airflow-data
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/airflow/pod_templates/okd/simple_task_template.yaml
+++ b/airflow/pod_templates/okd/simple_task_template.yaml
@@ -83,6 +83,9 @@ spec:
           mountPath: "/opt/airflow/config/airflow_local_settings.py"
           subPath: airflow_local_settings.py
           readOnly: true
+        - name: data
+          mountPath: "/opt/airflow/data"
+          readOnly: false
   restartPolicy: Never
   terminationGracePeriodSeconds: 600
   tolerations: []
@@ -95,6 +98,9 @@ spec:
     - name: config
       configMap:
         name: airflow-config
+    - name: data
+      persistentVolumeClaim:
+        claimName: airflow-data
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/airflow/pod_templates/openshift/medium_task_template.yaml
+++ b/airflow/pod_templates/openshift/medium_task_template.yaml
@@ -77,6 +77,9 @@ spec:
           mountPath: "/opt/airflow/airflow.cfg"
           subPath: airflow.cfg
           readOnly: true
+        - name: data
+          mountPath: "/opt/airflow/data"
+          readOnly: false
         - name: config
           mountPath: "/opt/airflow/config/airflow_local_settings.py"
           subPath: airflow_local_settings.py
@@ -93,3 +96,6 @@ spec:
     - name: config
       configMap:
         name: airflow-config
+    - name: data
+      persistentVolumeClaim:
+        claimName: airflow-data

--- a/airflow/pod_templates/openshift/simple_task_template.yaml
+++ b/airflow/pod_templates/openshift/simple_task_template.yaml
@@ -81,6 +81,9 @@ spec:
           mountPath: "/opt/airflow/config/airflow_local_settings.py"
           subPath: airflow_local_settings.py
           readOnly: true
+        - name: data
+          mountPath: "/opt/airflow/data"
+          readOnly: false
   restartPolicy: Never
   terminationGracePeriodSeconds: 600
   tolerations: []
@@ -93,3 +96,6 @@ spec:
     - name: config
       configMap:
         name: airflow-config
+    - name: data
+      persistentVolumeClaim:
+        claimName: airflow-data


### PR DESCRIPTION
# Description

I found this error message: 

```
Executor KubernetesExecutor(parallelism=32) reported that the task instance <TaskInstance: drive_bc_dag.drive_bc_scraper scheduled__2025-07-16T15:30:00+00:00 [queued]> finished with state failed, but the task instance's state attribute is queued. Learn more: https://airflow.apache.org/docs/apache-airflow/stable/troubleshooting.html#task-state-changed-externally Extra info: (422) Reason: Unprocessable Entity HTTP response headers: HTTPHeaderDict({'Audit-Id': '38664063-ef87-4e96-9607-70dff1caebb0', 'Cache-Control': 'no-cache, private', 'Content-Type': 'application/json', 'Strict-Transport-Security': 'max-age=31536000; includeSubDomains; preload', 'X-Kubernetes-Pf-Flowschema-Uid': '49a286c6-7281-4a4c-bd6b-53a139140b76', 'X-Kubernetes-Pf-Prioritylevel-Uid': '89a6cad1-326b-418b-8f21-35712d4d1498', 'Date': 'Wed, 16 Jul 2025 16:35:13 GMT', 'Content-Length': '429'}) HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"Pod \"drive-bc-dag-drive-bc-scraper-ic25v003\" is invalid: spec.containers[0].volumeMounts[3].name: Not found: \"data\"","reason":"Invalid","details":{"name":"drive-bc-dag-drive-bc-scraper-ic25v003","kind":"Pod","causes":[{"reason":"FieldValueNotFound","message":"Not found: \"data\"","field":"spec.containers[0].volumeMounts[3].name"}]},"code":422}
```

The most important field being the last 2 lines. I think this issue is caused by data being in the VolumeMount, but not in the volume, or vice versa. This also makes sense that hello_world is working, as it uses the simple template, which had not had data volume/volume mount defined.

I just added it to all of them.