### PR TITLE
Add Missing Slash

### DIFF
--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -25,7 +25,7 @@ export const getAllWatershedStations = async () => {
 }
 
 export const getWatershedByLatLng = async (lngLat) => {
-    return await requestWithErrorCatch(`${env.VITE_BASE_API_URL}/watershed?lat=${lngLat.lat}&lng=${lngLat.lng}`);
+    return await requestWithErrorCatch(`${env.VITE_BASE_API_URL}/watershed/?lat=${lngLat.lat}&lng=${lngLat.lng}`);
 }
 
 export const getWatershedReportByWFI = (wfi) => {


### PR DESCRIPTION
# Description

Fix Bug with Fetching Watershed: 

Try running `https://bcwatertool.fspatial/api/watershed/?lat=56.44253125282623&lng=-124.94032772431437` in browser

And then, try running `https://bcwatertool.fspatial/apiwatershed?lat=56.44253125282623&lng=-124.94032772431437`

You will see the bottom request will fail. This changes ensures that this succeeds.