### PR TITLE
Shade cells based on their hierarchy in row

### DIFF
--- a/client/src/components/MonthlyMeanFlowTable.vue
+++ b/client/src/components/MonthlyMeanFlowTable.vue
@@ -66,7 +66,11 @@ const props = defineProps({
     tableData: {
         type: Object,
         default: () => {},
-    }
+    },
+    flipOrder: {
+        type: Boolean,
+        default: false,
+    },
 });
 
 onMounted(async () => {
@@ -129,20 +133,30 @@ const getColorForRowAndCell = (row, column) => {
 
     // get only the non-string values, anything not '-'
     Object.keys(row).forEach(el => {
-        if (el !== "year" && el !== "term") {
+        if (el !== "year" && el !== "term" && row[el]) {
             valuesInRow.push(row[el]);
         }
-    })
+    });
 
-    const minimum = Math.min(...valuesInRow)
-    const ratio = (row[column] / minimum) * 99;
-
-    return `${cellColor}${ratio.toFixed(0)}`
+    const minimum = Math.min(...valuesInRow);
+    const maximum = Math.max(...valuesInRow);
+    if (row[column]) {
+        let ratio = 100 * (row[column] - minimum) / (maximum - minimum);
+        if (props.flipOrder) {
+            ratio = 100 - ratio;
+        }
+        ratio = Math.min(99, ratio);
+        if (ratio === 0) return `${cellColor}00`;
+        return `${cellColor}${ratio.toFixed(0)}`;
+    } else {
+        return `${cellColor}00`;
+    }
 };
 </script>
 
 <style lang="scss">
 .q-table__container {
-    max-height: calc(100vh - 2rem);
+    max-height: calc(100vh - 3rem);
+    overflow-y: auto;
 }
 </style>

--- a/client/src/components/groundwater-level/GroundWaterLevelReport.vue
+++ b/client/src/components/groundwater-level/GroundWaterLevelReport.vue
@@ -91,6 +91,7 @@
                     <MonthlyMeanFlowTable
                         v-if="props.reportData && 'monthly_mean_flow' in props.reportData && props.reportData.monthly_mean_flow"
                         :table-data="props.reportData.monthly_mean_flow"
+                        :flip-order="true"
                     />
                 </div>
             </q-tab-panel>


### PR DESCRIPTION
Shade values in mean monthly flow table by the values position relative to the min and max values. In the streamflow page the higher values get the deeper colours, while in the groundwater page the lower values get the deeper colours