### PR TITLE
indicies

### DIFF
--- a/database_initialization/queries/post_import_queries.py
+++ b/database_initialization/queries/post_import_queries.py
@@ -104,6 +104,59 @@ ALTER TABLE IF EXISTS "bcwat_obs"."station" DROP COLUMN IF EXISTS "old_station_i
         USING btree (station_id, variable_id)
 		INCLUDE (value, datestamp);
 
+	-- bc_wls_wrl_wra
+   CREATE INDEX IF NOT EXISTS fwa_stream_name_geom4326_idx
+        ON bcwat_ws.fwa_stream_name USING gist
+        (geom4326);
+
+    CREATE INDEX IF NOT EXISTS fwa_funds_geom4326_idx
+        ON bcwat_ws.fwa_fund USING gist
+        (geom4326);
+
+    CREATE INDEX IF NOT EXISTS sation_observation_composit_idx
+        ON bcwat_obs.station_observation
+        USING btree (station_id, variable_id)
+		INCLUDE (value, datestamp);
+
+	-- bc_wls_wrl_wra
+	CREATE INDEX IF NOT EXISTS idx_wrl_geom_gist
+		ON bcwat_lic.bc_wls_wrl_wra
+		USING GIST (geom4326);
+
+	CREATE INDEX IF NOT EXISTS idx_wrl_start_expiry
+		ON bcwat_lic.bc_wls_water_approval
+		(approval_start_date, approval_expiry_date);
+
+	CREATE INDEX IF NOT EXISTS idx_wrl_wls_id
+		ON bcwat_lic.bc_wls_wrl_wra
+ 		(wls_wrl_wra_id);
+
+	-- licence_ogc_short_term_approval
+	CREATE INDEX IF NOT EXISTS idx_ogc_geom_gist
+		ON bcwat_lic.licence_ogc_short_term_approval
+		USING GIST (geom4326);
+
+	CREATE INDEX IF NOT EXISTS idx_ogc_start_expiry
+		ON bcwat_lic.licence_ogc_short_term_approval
+  		(approved_start_date, approved_end_date);
+
+	CREATE INDEX IF NOT EXISTS idx_ogc_wls_id
+		ON bcwat_lic.licence_ogc_short_term_approval
+  		(short_term_approval_id);
+
+	-- bc_wls_water_approval
+	CREATE INDEX IF NOT EXISTS idx_water_approval_geom_gist
+		ON bcwat_lic.bc_wls_water_approval
+		USING GIST (geom4326);
+
+	CREATE INDEX IF NOT EXISTS idx_wa_start_expiry
+		ON bcwat_lic.bc_wls_water_approval
+		(approval_start_date, approval_expiry_date);
+
+	CREATE INDEX IF NOT EXISTS idx_water_approval_wls_id
+		ON bcwat_lic.bc_wls_water_approval
+		(bc_wls_water_approval_id);
+
 -- FUNCTIONS --
 CREATE OR REPLACE FUNCTION bcwat_lic.get_allocs_per_wfi(
 	in_wfi integer,


### PR DESCRIPTION
# Description

Added some indicies to assist with watershed report creation. We will likely not see much of a change on goose and OKD because our disks are slow and therefore have a high random page cost. When we run this on Openshift dev/test we may see the indicies being utilized due to the faster disks. While doing this I noted some areas for improvement if we can ever break this logic out of these stored procedures which will be quite time consuming, I think we can do this type of processing very very fast and there is no need for it to take as long as it does presently.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Closes #379 