### PR TITLE
 Find closest watershed not necessarily the one intersecting so one is always found

### DIFF
--- a/backend/queries/watershed/get_watershed_by_lat_lng.py
+++ b/backend/queries/watershed/get_watershed_by_lat_lng.py
@@ -35,12 +35,14 @@ get_watershed_by_lat_lng_query = """
 			LIMIT 1
 		) p
 	ON
-		ST_Intersects(p.pt_on_line_geom, root.geom4326)
+		ST_DWithin(root.geom4326, p.pt_on_line_geom, 0.01)
 	JOIN
 		bcwat_ws.ws_geom_all_report up
 	ON
 		up.watershed_feature_id = root.watershed_feature_id
 	WHERE
 		root.in_study_area
+	ORDER BY
+		ST_Distance(root.geom4326, p.pt_on_line_geom)
 	LIMIT 1;
 """


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

For the get watershed by lat long endpoint, we were often getting a "watershed not found" because the stream we snapped our selected point to was not inside one of our watersheds. I updated the logic of this query to get all watersheds close to that point and then take the one with the smallest distance. Mostly this is about the feel of selecting a watershed on the front end, so the best test would be to click around and compare behavior between this tool and others (I mostly used OWT for comparison)<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->