### PR TITLE
Nr bcwat 438 data tab only

### DIFF
--- a/client/src/components/climate/ClimateReport.vue
+++ b/client/src/components/climate/ClimateReport.vue
@@ -214,7 +214,7 @@
 </template>
 <script setup>
 import ReportChart from '@/components/ReportChart.vue';
-import { computed, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 
 const emit = defineEmits(["close"]);
 
@@ -486,7 +486,6 @@ const snowWaterChartData = computed(() => {
     }
 });
 
-
 const manualSnowChartOptions = computed(() => {
     return {
         name: 'manual-snow',
@@ -546,26 +545,27 @@ const currentReport = computed(() => {
 });
 
 // When the report changes, change the viewPage to whichever page has data
+onMounted(() => {
+    setReportMode();
+});
+
 watch(currentReport, () => {
+    setReportMode();
+});
+
+const setReportMode = () => {
     if (temperatureChartData.value.length >= 1) {
         viewPage.value = 'temperature';
-    }
-    else if (precipitationChartData.value.length >= 1) {
+    } else if (precipitationChartData.value.length >= 1) {
         viewPage.value = 'precipitation';
-    }
-    else if (snowOnGroundChartData.value.length >= 1) {
+    } else if (snowOnGroundChartData.value.length >= 1) {
         viewPage.value = 'snowOnGround';
-    }
-    else if (snowWaterChartData.value.length >= 1) {
+    } else if (snowWaterChartData.value.length >= 1) {
         viewPage.value = 'snowWaterEquivalent';
-    }
-    else if (manualSnowChartData.value.length >= 1) {
+    } else if (manualSnowChartData.value.length >= 1) {
         viewPage.value = 'manualSnowSurvey';
     }
-    else {
-        viewPage.value = 'temperature';
-    }
-});
+};
 </script>
 
 <style lang="scss">

--- a/client/src/components/climate/ClimateReport.vue
+++ b/client/src/components/climate/ClimateReport.vue
@@ -46,7 +46,7 @@
             <q-list class="report-list q-mt-sm">
                 <q-item
                     clickable
-                    :class="viewPage === '' ? 'active' : ''"
+                    :class="viewPage === 'temperature' ? 'active' : ''"
                     :disable="temperatureChartData.length < 1"
                     @click="() => (viewPage = 'temperature')"
                 >

--- a/client/src/components/climate/ClimateReport.vue
+++ b/client/src/components/climate/ClimateReport.vue
@@ -46,7 +46,7 @@
             <q-list class="report-list q-mt-sm">
                 <q-item
                     clickable
-                    :class="viewPage === 'temperature' ? 'active' : ''"
+                    :class="viewPage === '' ? 'active' : ''"
                     :disable="temperatureChartData.length < 1"
                     @click="() => (viewPage = 'temperature')"
                 >
@@ -214,7 +214,7 @@
 </template>
 <script setup>
 import ReportChart from '@/components/ReportChart.vue';
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 
 const emit = defineEmits(["close"]);
 
@@ -397,7 +397,7 @@ const snowOnGroundChartOptions = computed(() => {
 const snowOnGroundChartData = computed(() => {
     const myData = [];
     try {
-        if (props.reportContent.snow_on_ground_depth && (props.reportContent.temperature.current.length > 0 ||  props.reportContent.temperature.historical.length > 0)) {
+        if (props.reportContent.snow_on_ground_depth && (props.reportContent.snow_on_ground_depth.current.length > 0 ||  props.reportContent.snow_on_ground_depth.historical.length > 0)) {
             let currentDate = new Date(chartStart);
             const entryDateX = new Date(props.reportContent.snow_on_ground_depth.current[0].d);
             let day = Math.floor((entryDateX - new Date(entryDateX.getFullYear(), 0, 0)) / oneDay) - 1;
@@ -502,7 +502,6 @@ const manualSnowChartOptions = computed(() => {
 const manualSnowChartData = computed(() => {
     const myData = [];
     try {
-        console.log(props.reportContent.manual_snow_survey)
         if (props.reportContent.manual_snow_survey && (props.reportContent.manual_snow_survey.current.length > 0 || props.reportContent.manual_snow_survey.historical.length > 0)) {
             let currentDate = new Date(chartStart);
             const entryDateX = new Date(props.reportContent.manual_snow_survey.current[0].d);
@@ -536,6 +535,35 @@ const manualSnowChartData = computed(() => {
         console.error(e);
     } finally {
         return myData;
+    }
+});
+
+const currentReport = computed(() => {
+    if (props.reportContent) {
+        return props.reportContent;
+    }
+    return null;
+});
+
+// When the report changes, change the viewPage to whichever page has data
+watch(currentReport, () => {
+    if (temperatureChartData.value.length >= 1) {
+        viewPage.value = 'temperature';
+    }
+    else if (precipitationChartData.value.length >= 1) {
+        viewPage.value = 'precipitation';
+    }
+    else if (snowOnGroundChartData.value.length >= 1) {
+        viewPage.value = 'snowOnGround';
+    }
+    else if (snowWaterChartData.value.length >= 1) {
+        viewPage.value = 'snowWaterEquivalent';
+    }
+    else if (manualSnowChartData.value.length >= 1) {
+        viewPage.value = 'manualSnowSurvey';
+    }
+    else {
+        viewPage.value = 'temperature';
     }
 });
 </script>

--- a/client/src/components/streamflow/StreamflowReport.vue
+++ b/client/src/components/streamflow/StreamflowReport.vue
@@ -142,7 +142,7 @@ import FlowDurationTool from "@/components/streamflow//FlowDurationTool.vue";
 import FlowMetrics from "@/components/streamflow/FlowMetrics.vue";
 import MonthlyMeanFlowTable from "@/components/MonthlyMeanFlowTable.vue";
 import StreamflowStage from "@/components/streamflow/StreamflowStage.vue";
-import { computed, ref, watch } from 'vue';
+import { computed, ref, watch, onMounted } from 'vue';
 
 const emit = defineEmits(['close']);
 
@@ -220,26 +220,29 @@ const currentReport = computed(() => {
 });
 
 // When the report changes, change the viewPage to whichever page has data
+onMounted(() => {
+    setReportMode();
+});
+
 watch(currentReport, () => {
+    setReportMode();
+});
+
+const setReportMode = () => {
     if (hasSevenDay.value) {
         viewPage.value = 'sevenDayFlow';
-    }
-    else if (hasFlowDuration.value) {
+    } else if (hasFlowDuration.value) {
         viewPage.value = 'flowDurationTool';
-    }
-    else if (props.reportData?.hasFlowMetrics) {
+    } else if (props.reportData?.hasFlowMetrics) {
         viewPage.value = 'flowMetrics';
-    }
-    else if (hasMonthlyMeanFlow.value) {
+    } else if (hasMonthlyMeanFlow.value) {
         viewPage.value = 'monthlyMeanFlow';
-    }
-    else if (hasStage.value) {
+    } else if (hasStage.value) {
         viewPage.value = 'stage';
-    }
-    else {
+    } else {
         viewPage.value = 'sevenDayFlow';
     }
-});
+};
 
 </script>
 

--- a/client/src/components/streamflow/StreamflowReport.vue
+++ b/client/src/components/streamflow/StreamflowReport.vue
@@ -142,7 +142,7 @@ import FlowDurationTool from "@/components/streamflow//FlowDurationTool.vue";
 import FlowMetrics from "@/components/streamflow/FlowMetrics.vue";
 import MonthlyMeanFlowTable from "@/components/MonthlyMeanFlowTable.vue";
 import StreamflowStage from "@/components/streamflow/StreamflowStage.vue";
-import { computed, ref } from 'vue';
+import { computed, ref, watch } from 'vue';
 
 const emit = defineEmits(['close']);
 
@@ -162,6 +162,26 @@ const props = defineProps({
 });
 
 const viewPage = ref('sevenDayFlow');
+
+watch(reportData, () => {
+    viewPage.value = () => {
+        if (hasSevenDay) {
+            return 'sevenDayFlow';
+        }
+        else if (hasFlowDuration) {
+            return 'flowDurationTool';
+        }
+        else if(props.reportData.hasFlowMetrics) {
+            return 'flowMetrics';
+        }
+        else if (hasMonthlyMeanFlow) {
+            return 'monthlyMeanFlow';
+        }
+        else if (hasStage) {
+            return 'stage';
+        }
+    }
+})
 
 const startYear = computed(() => {
     if(typeof props.activePoint.yr === 'string'){

--- a/client/src/components/streamflow/StreamflowReport.vue
+++ b/client/src/components/streamflow/StreamflowReport.vue
@@ -163,25 +163,6 @@ const props = defineProps({
 
 const viewPage = ref('sevenDayFlow');
 
-watch(reportData, () => {
-    viewPage.value = () => {
-        if (hasSevenDay) {
-            return 'sevenDayFlow';
-        }
-        else if (hasFlowDuration) {
-            return 'flowDurationTool';
-        }
-        else if(props.reportData.hasFlowMetrics) {
-            return 'flowMetrics';
-        }
-        else if (hasMonthlyMeanFlow) {
-            return 'monthlyMeanFlow';
-        }
-        else if (hasStage) {
-            return 'stage';
-        }
-    }
-})
 
 const startYear = computed(() => {
     if(typeof props.activePoint.yr === 'string'){
@@ -234,6 +215,34 @@ const hasStage = computed(() => {
     }
 })
 
+const currentReport = computed(() => {
+    if (props.reportData) {
+        return props.reportData;
+    }
+    return null;
+});
+
+// When the report changes, change the viewPage to whichever page has data
+watch(currentReport, () => {
+    if (hasSevenDay.value) {
+        viewPage.value = 'sevenDayFlow';
+    }
+    else if (hasFlowDuration.value) {
+        viewPage.value = 'flowDurationTool';
+    }
+    else if (props.reportData?.hasFlowMetrics) {
+        viewPage.value = 'flowMetrics';
+    }
+    else if (hasMonthlyMeanFlow.value) {
+        viewPage.value = 'monthlyMeanFlow';
+    }
+    else if (hasStage.value) {
+        viewPage.value = 'stage';
+    }
+    else {
+        viewPage.value = 'sevenDayFlow';
+    }
+});
 
 </script>
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Added watchers to StreamflowReport.vue and ClimateReport.vue that will update the viewPage to only show a page with data available. Some other small fixes, fixed a console.error for climate reports without snow depth but with temperature.

To test, please check out different streamflow and climate reports with different data availability and see that a chart with data available is opened when the page is.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->