### PR TITLE
Pgbouncer test on okd

### DIFF
--- a/airflow/etl_pipelines/utils/database.py
+++ b/airflow/etl_pipelines/utils/database.py
@@ -17,7 +17,7 @@ pgschema_prefix = os.getenv("PGSCHEMA_PREFIX")
 class Database:
 	def __init__(self):
 		self.conn = self.connect()
-		self.pool = ThreadedConnectionPool(minconn=1, maxconn=10, host = host, database = database, user = user, password = password, port = port)
+		self.pool = ThreadedConnectionPool(minconn=1, maxconn=200, host = host, database = database, user = user, password = password, port = port)
 
 	def connect(self):
 		"""

--- a/charts/okd/app/templates/backend/templates/deployment.yaml
+++ b/charts/okd/app/templates/backend/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: {{ .Values.migrations.secret }}
-                  key: host
+                  key: pgbouncer-host
             - name: POSTGRES_DB
               valueFrom:
                 secretKeyRef:

--- a/charts/okd/app/values.yaml
+++ b/charts/okd/app/values.yaml
@@ -23,5 +23,5 @@ backend:
 
 migrations:
   image: foundrymainregistry.azurecr.io/bcwat/flyway:latest
-  secret: bcwat-db-pguser-bcwat-api-admin
+  secret: bcwat-db-pguser-bcwat-api-read-only
   imagePullSecret: acr-pull-secret

--- a/charts/okd/crunchy/PostgresCluster.yaml
+++ b/charts/okd/crunchy/PostgresCluster.yaml
@@ -54,3 +54,35 @@ spec:
           tcp_keepalives_idle: 300
           tcp_keepalives_interval: 60
           tcp_keepalives_count: 10
+  proxy:
+    pgBouncer:
+      config:
+        global:
+          client_tls_sslmode: disable
+          pool_mode: session
+          max_db_connections: 40
+
+      replicas: 1
+      # these resources are for the "pgbouncer" container in the "postgres-crunchy-ha-pgbouncer" set of pods
+      # there is a sidecar in these pods which are not mentioned here, but the requests/limits are teeny weeny by default so no worries there.
+      resources:
+        requests:
+          cpu: 5m
+          memory: 32Mi
+      sidecars:
+        pgbouncerConfig:
+          resources:
+            requests:
+              cpu: 5m
+              memory: 32Mi
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    postgres-operator.crunchydata.com/cluster: bcwat-db
+                    postgres-operator.crunchydata.com/role: pgbouncer
+                    app.kubernetes.io/namespace: bcwat

--- a/charts/okd/crunchy/PostgresCluster.yaml
+++ b/charts/okd/crunchy/PostgresCluster.yaml
@@ -74,13 +74,13 @@ spec:
       resources:
         requests:
           cpu: 5m
-          memory: 32Mi
+          memory: 64Mi
       sidecars:
         pgbouncerConfig:
           resources:
             requests:
               cpu: 5m
-              memory: 32Mi
+              memory: 64Mi
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/okd/crunchy/PostgresCluster.yaml
+++ b/charts/okd/crunchy/PostgresCluster.yaml
@@ -60,7 +60,7 @@ spec:
         global:
           client_tls_sslmode: disable
           pool_mode: session
-          max_db_connections: 40
+          max_db_connections: "40"
 
       replicas: 1
       # these resources are for the "pgbouncer" container in the "postgres-crunchy-ha-pgbouncer" set of pods

--- a/charts/okd/crunchy/PostgresCluster.yaml
+++ b/charts/okd/crunchy/PostgresCluster.yaml
@@ -16,6 +16,12 @@ spec:
       databases:
         - bcwat_dev
       options: "SUPERUSER"
+    - name: bcwat-api-read-only
+      databases:
+        - bcwat_dev
+    - name: bcwat-airflow-read-write
+      databases:
+        - bcwat_dev
   instances:
     - name: bcwat
       replicas: 1
@@ -60,7 +66,7 @@ spec:
         global:
           client_tls_sslmode: disable
           pool_mode: session
-          max_db_connections: "40"
+          max_db_connections: "25"
 
       replicas: 1
       # these resources are for the "pgbouncer" container in the "postgres-crunchy-ha-pgbouncer" set of pods

--- a/charts/openshift/crunchy/values.dev.yaml
+++ b/charts/openshift/crunchy/values.dev.yaml
@@ -109,14 +109,14 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
         tcp_keepalives_count: 10 # after 10 failed responses pronounce the connection dead
 
   proxy:
-    enabled: false
+    enabled: true
     pgBouncer:
       image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
       replicas: 1
       requests:
         cpu: 5m
         memory: 32Mi
-      maxConnections: 10 # make sure less than postgres max connections
+      maxConnections: 40 # make sure less than postgres max connections
 
   # Postgres Cluster resource values:
   pgmonitor:

--- a/migrations/sql/V1.0.4_db_user_permissions.sql
+++ b/migrations/sql/V1.0.4_db_user_permissions.sql
@@ -1,0 +1,25 @@
+ALTER DEFAULT PRIVILEGES IN SCHEMA bcwat_lic GRANT SELECT ON TABLES TO "bcwat-api-read-only";
+ALTER DEFAULT PRIVILEGES IN SCHEMA bcwat_obs GRANT SELECT ON TABLES TO "bcwat-api-read-only";
+ALTER DEFAULT PRIVILEGES IN SCHEMA bcwat_ws GRANT SELECT ON TABLES TO "bcwat-api-read-only";
+
+GRANT USAGE ON SCHEMA bcwat_lic TO "bcwat-api-read-only";
+GRANT USAGE ON SCHEMA bcwat_obs TO "bcwat-api-read-only";
+GRANT USAGE ON SCHEMA bcwat_ws TO "bcwat-api-read-only";
+
+GRANT SELECT ON ALL TABLES IN SCHEMA bcwat_lic TO "bcwat-api-read-only";
+GRANT SELECT ON ALL TABLES IN SCHEMA bcwat_obs TO "bcwat-api-read-only";
+GRANT SELECT ON ALL TABLES IN SCHEMA bcwat_ws TO "bcwat-api-read-only";
+
+GRANT EXECUTE ON ALL FUNCTIONS IN SCHEMA bcwat_lic TO "bcwat-api-read-only";
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA bcwat_lic GRANT SELECT, UPDATE, DELETE, TRUNCATE, INSERT ON TABLES TO "bcwat-airflow-read-write";
+ALTER DEFAULT PRIVILEGES IN SCHEMA bcwat_obs GRANT SELECT, UPDATE, DELETE, TRUNCATE, INSERT ON TABLES TO "bcwat-airflow-read-write";
+ALTER DEFAULT PRIVILEGES IN SCHEMA bcwat_ws GRANT SELECT, UPDATE, DELETE, TRUNCATE, INSERT ON TABLES TO "bcwat-airflow-read-write";
+
+GRANT USAGE ON SCHEMA bcwat_lic TO "bcwat-airflow-read-write";
+GRANT USAGE ON SCHEMA bcwat_obs TO "bcwat-airflow-read-write";
+GRANT USAGE ON SCHEMA bcwat_ws TO "bcwat-airflow-read-write";
+
+GRANT SELECT, UPDATE, DELETE, TRUNCATE, INSERT ON ALL TABLES IN SCHEMA bcwat_lic TO "bcwat-airflow-read-write";
+GRANT SELECT, UPDATE, DELETE, TRUNCATE, INSERT ON ALL TABLES IN SCHEMA bcwat_obs TO "bcwat-airflow-read-write";
+GRANT SELECT, UPDATE, DELETE, TRUNCATE, INSERT ON ALL TABLES IN SCHEMA bcwat_ws TO "bcwat-airflow-read-write";


### PR DESCRIPTION
# Description

Initialize PgBouncer for handling our Connection Pool on OKD.

The goal of this is to provide the framework for handling connections to our crunchy databased on Openshift.

## Types of changes

Enable PgBouncer, create new users, include permissions that were manually applied within the migrations table. Will discuss with Kash what to do about db migrations on flyway once he has returned.
