### PR TITLE
Initializing Prod DB with replicas, defaulting pgbackrest off (for now)

### DIFF
--- a/charts/openshift/airflow/prerequisites/prod/PersistentVolumeClaim.yaml
+++ b/charts/openshift/airflow/prerequisites/prod/PersistentVolumeClaim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: airflow-data
+  namespace: cdd771-prod
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 15Gi
+  storageClassName: netapp-file-standard
+  volumeMode: Filesystem

--- a/charts/openshift/airflow/values.prod.yaml
+++ b/charts/openshift/airflow/values.prod.yaml
@@ -1,0 +1,75 @@
+executor: KubernetesExecutor
+
+# Requires Existing Storage Class Created (handled by FLUX CD - INFRA)
+logs:
+  persistence:
+    enabled: true
+    storageClassName: netapp-file-standard
+    size: 8Gi
+
+# We are manaully creating a fernet-key before initializing Airflow.
+fernetKeySecretName: airflow-fernet-key
+webserverSecretKeySecretName: airflow-webserver-secret-key
+
+# Airflow database config
+# Requires Airflow-metadata secret to have been created, pointing to the database handling airflow metadata info
+data:
+  metadataSecretName: airflow-database-connection
+  resultBackendSecretName: airflow-database-connection
+
+images:
+  airflow:
+    repository: ghcr.io/bcgov/nr-bcwat/airflow
+    tag: latest
+    pullPolicy: Always
+
+webserver:
+  waitForMigrations:
+    enabled: false
+  securityContext:
+    runAsUser: 1017940000
+    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
+
+scheduler:
+  waitForMigrations:
+    enabled: false
+  securityContext:
+    runAsUser: 1017940000
+    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
+
+migrateDatabaseJob:
+  securityContext:
+    runAsUser: 1017940000
+    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
+  ttlSecondsAfterFinished: 180
+
+createUserJob:
+  securityContext:
+    runAsUser: 1017940000
+    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
+  ttlSecondsAfterFinished: 180
+
+redis:
+  enabled: false
+
+triggerer:
+  persistence:
+    enabled: false
+  waitForMigrations:
+    enabled: false
+  securityContext:
+    runAsUser: 1017940000
+    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
+
+postgresql:
+  enabled: false
+
+flower:
+  enabled: false
+
+statsd:
+  enabled: false
+
+dags:
+  persistence:
+    enabled: false

--- a/charts/openshift/crunchy/values.prod.yaml
+++ b/charts/openshift/crunchy/values.prod.yaml
@@ -35,7 +35,7 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       storageClassName: netapp-block-standard
       walStorage: 10Gi
     requests:
-      memory: 6Gi
+      memory: 3Gi
     limits:
       memory: 6Gi
     replicaCertCopy:

--- a/charts/openshift/crunchy/values.prod.yaml
+++ b/charts/openshift/crunchy/values.prod.yaml
@@ -25,17 +25,18 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
     target: ~ # 2024-03-24 17:16:00-07 this is the target timestamp to go back to in current cluster
   instances:
     name: db # high availability
-    replicas: 1 # 2 or 3 for high availability in TEST and PROD.
+    replicas: 2 # 2 or 3 for high availability in TEST and PROD.
     metadata:
       annotations:
         prometheus.io/scrape: 'true'
         prometheus.io/port: '9187'
     dataVolumeClaimSpec:
-      storage: 150Gi
+      storage: 165Gi
       storageClassName: netapp-block-standard
-      walStorage: 1Gi
+      walStorage: 10Gi
     requests:
-      cpu: 2M
+      memory: 6Gi
+    limits:
       memory: 6Gi
     replicaCertCopy:
       requests:
@@ -44,6 +45,46 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
 
   pgBackRest:
     enabled: false # Testing Initialization, Resource Constraints
+    backupPath: /backups/test/cluster/version # change it for PROD, create values-prod.yaml
+    clusterCounter: 2 # this is the number to identify what is the current counter for the cluster, each time it is cloned it should be incremented.
+    # If retention-full-type set to 'count' then the oldest backups will expire when the number of backups reach the number defined in retention
+    # If retention-full-type set to 'time' then the number defined in retention will take that many days worth of full backups before expiration
+    retentionFullType: count
+    s3:
+      enabled: false # if enabled, below must be provided
+      retention: 7 # one weeks backup in object store.
+      bucket: ~
+      endpoint: ~
+      accessKey: ~
+      secretKey: ~
+      fullBackupSchedule: 0 9 * * *
+      incrementalBackupSchedule: 0 0/5 * * * # every 5 hour incremental
+    pvc:
+      retention: 1 # one day hot active backup in pvc
+      retentionFullType: count
+      fullBackupSchedule: 0 8 * * *
+      incrementalBackupSchedule: 0 0,12 * * * # every 12 hour incremental
+      volume:
+        accessModes: "ReadWriteOnce"
+        storage: 100Mi
+        storageClassName: netapp-file-backup
+
+    config:
+      requests:
+        cpu: 5m
+        memory: 32Mi
+    repoHost:
+      requests:
+        cpu: 20m
+        memory: 128Mi
+    sidecars:
+      requests:
+        cpu: 5m
+        memory: 16Mi
+    jobs:
+      requests:
+        cpu: 20m
+        memory: 128Mi
 
   patroni:
     postgresql:
@@ -54,7 +95,7 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
         shared_buffers: 1500MB # default is 128MB; a good tuned default for shared_buffers is 25% of the memory allocated to the pod
         wal_buffers: -1 # this can be set to -1 to automatically set as 1/32 of shared_buffers or 64kB, whichever is larger
         min_wal_size: 32MB
-        max_wal_size: 500MB # default is 1GB
+        max_wal_size: 4GB # default is 1GB
         max_slot_wal_keep_size: -1 # default is -1, allowing unlimited wal growth when replicas fall behind
         work_mem: 8MB # a work_mem value of 2 MB
         log_min_duration_statement: 1000ms # log queries taking more than 1 second to respond.
@@ -68,14 +109,16 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
         tcp_keepalives_count: 10 # after 10 failed responses pronounce the connection dead
 
   proxy:
-    enabled: false
+    enabled: true
     pgBouncer:
       image: # it's not necessary to specify an image as the images specified in the Crunchy Postgres Operator will be pulled by default
-      replicas: 1
+      replicas: 2
       requests:
         cpu: 5m
-        memory: 32Mi
-      maxConnections: 10 # make sure less than postgres max connections
+        memory: 64Mi
+      maxConnections: "25" # make sure less than postgres max connections
+      clientTlsSslmode: disable
+      poolMode: session
 
   # Postgres Cluster resource values:
   pgmonitor:
@@ -93,27 +136,17 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
   # For more details, refer to the Crunchy Postgres Operator documentation:
   # https://access.crunchydata.com/documentation/postgres-operator/latest/tutorials/basic-setup/user-management
   users:
-  #   - name: '{{ .Values.global.config.dbName }}'
-  #     databases:
-  #       - '{{ .Values.global.config.dbName }}-airflow-metadata'
-  #     options: "SUPERUSER CREATEDB CREATEROLE"
-  #   - name: 'postgres'
-  #     databases:
-  #       - 'postgres'
-  #       - '{{ .Values.global.config.dbName }}'
-  #   - name: '{{ .Values.global.config.dbName }}proxy'
-  #     databases:
-  #       - '{{ .Values.global.config.dbName }}'
-  #       - 'postgres'
-  #   - name: '{{ .Values.global.config.dbName }}proxytest'
-  #     databases:
-  #       - '{{ .Values.global.config.dbName }}'
-  #       - 'postgres'
     - name: airflow-metadata-admin
       databases:
         - airflow_metadata
       options: "SUPERUSER CREATEDB CREATEROLE"
     - name: bcwat-api-admin
       databases:
-        - bcwat_dev
+        - bcwat_prod
       options: "SUPERUSER CREATEDB CREATEROLE"
+    - name: bcwat-api-read-only
+      databases:
+        - bcwat_prod
+    - name: bcwat-airflow-read-write
+      databases:
+        - bcwat_prod

--- a/charts/openshift/restore-db/knp.yaml
+++ b/charts/openshift/restore-db/knp.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   podSelector:
     matchLabels:
-      postgres-operator.crunchydata.com/cluster: bcwat-test-crunchy
+      postgres-operator.crunchydata.com/cluster: bcwat-prod-crunchy
   ingress:
     - ports:
         - protocol: TCP

--- a/charts/openshift/restore-db/restore.yaml
+++ b/charts/openshift/restore-db/restore.yaml
@@ -2,7 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: restore-crunchy-from-s3
-  namespace: cdd771-test
+  namespace: cdd771-prod
 spec:
   backoffLimit: 0
   template:
@@ -19,27 +19,27 @@ spec:
             - name: DB_HOST
               valueFrom:
                 secretKeyRef:
-                  name: bcwat-test-crunchy-pguser-bcwat-api-admin
+                  name: bcwat-prod-crunchy-pguser-bcwat-api-admin
                   key: host
             - name: DB_PORT
               valueFrom:
                 secretKeyRef:
-                  name: bcwat-test-crunchy-pguser-bcwat-api-admin
+                  name: bcwat-prod-crunchy-pguser-bcwat-api-admin
                   key: port
             - name: DB_NAME
               valueFrom:
                 secretKeyRef:
-                  name: bcwat-test-crunchy-pguser-bcwat-api-admin
+                  name: bcwat-prod-crunchy-pguser-bcwat-api-admin
                   key: dbname
             - name: DB_USER
               valueFrom:
                 secretKeyRef:
-                  name: bcwat-test-crunchy-pguser-bcwat-api-admin
+                  name: bcwat-prod-crunchy-pguser-bcwat-api-admin
                   key: user
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
-                  name: bcwat-test-crunchy-pguser-bcwat-api-admin
+                  name: bcwat-prod-crunchy-pguser-bcwat-api-admin
                   key: password
             - name: AWS_ACCESS_KEY_ID
               valueFrom:
@@ -62,7 +62,7 @@ spec:
                   name: s3-secrets
                   key: ENDPOINT_URL
             - name: BACKUP_FILE
-              value: 2025-08-06-bcwat_dev.dump
+              value: 2025-08-08-bcwat_dev.dump
           resources:
             requests:
               cpu: 1000m


### PR DESCRIPTION
# Description

Simple Init of Prod Database, created via command within README. 

I will be automating this process in the future.

Furthermore, I will turn pgbackrest on in the future - I would like to experiment with it OnPrem before backing up to s3 from openshift

<img width="1561" height="431" alt="image" src="https://github.com/user-attachments/assets/1e5762ef-05d4-45bc-b636-9ce1d78151da" />
