### PR TITLE
adding flyway migration that updates `in_study_area` flag

### DIFF
--- a/migrations/sql/V1.0.3__fix_in_study_area_falgs.sql
+++ b/migrations/sql/V1.0.3__fix_in_study_area_falgs.sql
@@ -1,0 +1,29 @@
+WITH study_area AS (
+    SELECT
+        ST_Buffer(
+            ST_Union(
+                region_click_studyarea
+            ),
+            0.0001
+        ) AS geom
+    FROM
+        bcwat_obs.region
+    WHERE
+        region_id IN (3,4,5,6)
+)
+UPDATE
+    bcwat_ws.fwa_fund
+SET
+    in_study_area = True
+WHERE
+    ST_Intersects(
+        geom4326,
+        (
+            SELECT
+                geom
+            FROM
+                study_area
+        )
+    )
+AND
+    in_study_area = False;


### PR DESCRIPTION
Noticed that some areas in Omineca didn't generate a watershed report on click. This was because the `in_study_area` flag wasn't properly set for some of the watersheds in the `fwa_funds` table.
This migration will fix those values.