### PR TITLE
Added clean_up method call to quarterly_gw_moe_dag.py

### DIFF
--- a/airflow/dags/quarterly_gw_moe_dag.py
+++ b/airflow/dags/quarterly_gw_moe_dag.py
@@ -39,6 +39,7 @@ def run_quarterly_gw_moe_update_dag():
         gw_quarterly_scraper.validate_downloaded_data()
         gw_quarterly_scraper.transform_data()
         gw_quarterly_scraper.load_data()
+        gw_quarterly_scraper.clean_up()
 
     @task(
         executor_config=executor_config_template,
@@ -62,6 +63,7 @@ def run_quarterly_gw_moe_update_dag():
         gw_daily_scraper.transform_data()
         gw_daily_scraper.load_data()
         gw_daily_scraper.check_year_in_station_year()
+        gw_daily_scraper.clean_up()
 
     run_quarterly_gw_moe_update() >> run_daily_gw_moe()
 


### PR DESCRIPTION
`quarterly_gw_moe_dag.py` calls the daily version of `gw_moe` as well which downloads a file. This requires a `clean_up` method to be called, which was forgot.