### PR TITLE
Change allocations display. Add watershed loader

### DIFF
--- a/client/src/components/watershed/Watershed.vue
+++ b/client/src/components/watershed/Watershed.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <div
-            v-if="mapLoading"
+            v-if="loading"
             class="loader-container"
         >
             <q-spinner
@@ -9,19 +9,7 @@
                 size="xl"
             />
             <div>
-                Loading points. Please wait...
-            </div>
-        </div>
-        <div
-            v-if="reportLoading"
-            class="loader-container"
-        >
-            <q-spinner
-                class="map-loader"
-                size="xl"
-            />
-            <div>
-                Loading report data. Please wait...
+                {{ loadingMsg }}
             </div>
         </div>
         <div>
@@ -126,8 +114,9 @@ import { computed, ref } from "vue";
 const map = ref();
 const points = ref();
 const pointsLoading = ref(false);
+const loading = ref(false);
+const loadingMsg = ref('Loading points. Please wait...');
 const reportContent = ref(null);
-const reportLoading = ref(false);
 const activePoint = ref();
 const clickedPoint = ref(null);
 const showMultiPointPopup = ref(false);
@@ -135,7 +124,6 @@ const watershedInfo = ref(null);
 const watershedPolygon = ref(null);
 const reportOpen = ref(false);
 const features = ref([]);
-const mapLoading = ref(false);
 const firstSymbolId = ref();
 const allFeatures = ref([]);
 const allQueriedPoints = ref();
@@ -268,7 +256,8 @@ const pointCount = computed(() => {
  * @param mapObj Mapbox Map
  */
 const loadPoints = async (mapObj) => {
-    mapLoading.value = true;
+    loading.value = true;
+    loadingMsg.value = "Loading points. Please wait..."
     pointsLoading.value = true;
     map.value = mapObj;
 
@@ -353,7 +342,7 @@ const loadPoints = async (mapObj) => {
     map.value.once("idle", () => {
         features.value = getVisibleLicenses();
     });
-    mapLoading.value = false;
+    loading.value = false;
 };
 
 /**
@@ -366,11 +355,15 @@ const clickMap = (coordinates) => {
 };
 
 const getWatershedInfoAtLngLat = async (coordinates) => {
+    loading.value = true;
+    loadingMsg.value = "Loading Watershed. Please wait..."
     watershedInfo.value = await getWatershedByLatLng(coordinates);
     getWatershedInfo();
 };
 
 const getWatershedInfoByWFI = async (wfi) => {
+    loading.value = true;
+    loadingMsg.value = "Loading Watershed. Please wait..."
     watershedInfo.value = await getWatershedByWFI(wfi);
     clickedPoint.value = { lng: watershedInfo.value.geojson.coordinates[0][0][0], lat: watershedInfo.value.geojson.coordinates[0][0][1] };
     getWatershedInfo();
@@ -404,6 +397,7 @@ const getWatershedInfo = async () => {
             console.error('unable to set watershed polygon');
         }
     }
+    loading.value = false;
 };
 
 const goToLocation = (polygon) => {
@@ -412,9 +406,10 @@ const goToLocation = (polygon) => {
 };
 
 const openReport = async () => {
-    reportLoading.value = true;
+    loading.value = true;
+    loadingMsg.value = "Loading report data. Please wait..."
     reportContent.value = await getWatershedReportByWFI(watershedInfo.value.wfi);
-    reportLoading.value = false;
+    loading.value = false;
     if (reportContent.value) {
         reportOpen.value = true;
     }

--- a/client/src/components/watershed/report/MonthlyHydrologyChart.vue
+++ b/client/src/components/watershed/report/MonthlyHydrologyChart.vue
@@ -174,14 +174,13 @@ onMounted(() => {
         .attr("height", (d) => y(d[0]) - y(d[1]))
         .attr("width", x.bandwidth());
 
-    console.log(height, myData)
     svg.value.append("g")
         .selectAll()
         .data(myData)
         .join("rect")
         .attr("x", (d) => x(d.group))
         .attr("y", (d) => y(d.rm3 + d.rm2 + d.rm1))
-        .attr("height", (d) => height - y(d.existing))
+        .attr("height", (d) => Math.min(height - y(d.existing), height - y(d.rm3 + d.rm2 + d.rm1)))
         .attr("width", x.bandwidth())
         .attr("fill", '#ffffff00')
         .attr("stroke", 'black')

--- a/client/src/components/watershed/report/MonthlyHydrologyChart.vue
+++ b/client/src/components/watershed/report/MonthlyHydrologyChart.vue
@@ -106,7 +106,7 @@ onMounted(() => {
             existing: props.chartData.existingAllocations[idx],
         });
     });
-    const subgroups = ["rm1", "rm2", "rm3", "existing"];
+    const subgroups = ["rm1", "rm2", "rm3"];
 
     // Add X axis
     const x = d3
@@ -153,7 +153,7 @@ onMounted(() => {
     const color = d3
         .scaleOrdinal()
         .domain(subgroups)
-        .range(["#194666", "#3082be", "#99c6e6", "#c00"]);
+        .range(["#194666", "#3082be", "#99c6e6"]);
 
     // Create stacked data
     const stackedData = d3.stack().keys(subgroups)(myData);
@@ -173,6 +173,19 @@ onMounted(() => {
         .attr("y", (d) => y(d[1]))
         .attr("height", (d) => y(d[0]) - y(d[1]))
         .attr("width", x.bandwidth());
+
+    console.log(height, myData)
+    svg.value.append("g")
+        .selectAll()
+        .data(myData)
+        .join("rect")
+        .attr("x", (d) => x(d.group))
+        .attr("y", (d) => y(d.rm3 + d.rm2 + d.rm1))
+        .attr("height", (d) => height - y(d.existing))
+        .attr("width", x.bandwidth())
+        .attr("fill", '#ffffff00')
+        .attr("stroke", 'black')
+        .attr("stroke-width", "2px")
 
     bindTooltipHandlers();
 });

--- a/client/src/components/watershed/report/MonthlyHydrologyLegend.vue
+++ b/client/src/components/watershed/report/MonthlyHydrologyLegend.vue
@@ -4,7 +4,7 @@
             <tbody>
                 <tr>
                     <td colspan="2">Existing Allocations</td>
-                    <td><div class="legend-color existing"></div></td>
+                    <td><div class="legend-color"></div></td>
                 </tr>
                 <tr>
                     <td colspan="2">Risk Management 3</td>
@@ -21,7 +21,7 @@
                 <tr>
                     <td>MAD</td>
                     <td>{{ props.mad.toFixed(2) }} m³/s</td>
-                    
+
                     <td>
                         <div
                             class="legend-line"
@@ -87,10 +87,6 @@ const props = defineProps({
         border: 2px solid black;
         border-radius: 3px;
         height: 1em;
-        
-        &.existing {
-            background-color: $existing-allocations-stroke-color;
-        }
         &.rm3 {
             background-color: $risk-mgmt-level-3-color;
         }
@@ -105,11 +101,11 @@ const props = defineProps({
     .legend-line {
         display: flex;
         align-items: center;
-    
+
         .line {
             border-width: 2px;
             width: 2.5em;
- 
+
             &.dashed {
                 border-style: dashed;
 


### PR DESCRIPTION
Add loader to watershed page when loading a watershed polygon

Change how existing allocations are displayed. They now extent down the chart as a means of identifying how much of the available water has been allocated 