### PR TITLE
final typo - create webserver secret key

### DIFF
--- a/.github/workflows/.airflow-deployer.yml
+++ b/.github/workflows/.airflow-deployer.yml
@@ -166,7 +166,7 @@ jobs:
               --set-string secrets.bcwatFlowworks.password="${{ secrets.airflow_flowworks_password }}" \
               --set-string secrets.bcwatFlowworks.username="${{ secrets.airflow_flowworks_username }}" \
               --set-string secrets.fernet.key="${{ secrets.airflow_fernet_key }}" \
-              --set-string secrets.webserver.key="${{ secrets.airflow_webserver_secret_key }}"
+              --set-string secrets.webserver.key="${{ secrets.airflow_webserver_secret_key }}" \
               --set-string secrets.sendgridApiKey="${{ secrets.airflow_sendgrid_api_key }}" \
               ./${{ github.event.repository.name }}-${{steps.vars.outputs.version }}.tgz
 


### PR DESCRIPTION
# Description

Webserver Secret Key was not created on Dev, causing config errors. It already exists on test, which was why the test airflow succeeded.
