### PR TITLE
raising max connections

### DIFF
--- a/backend/database.py
+++ b/backend/database.py
@@ -20,7 +20,7 @@ class Database:
         host = os.getenv("POSTGRES_HOST")
 
         try:
-            self.pool = ThreadedConnectionPool(minconn=1, maxconn=5, host = host, database = database, user = user, password = password, port = port, keepalives=1, keepalives_idle=30, keepalives_interval=10, keepalives_count=5)
+            self.pool = ThreadedConnectionPool(minconn=1, maxconn=50, host = host, database = database, user = user, password = password, port = port, keepalives=1, keepalives_idle=30, keepalives_interval=10, keepalives_count=5)
             logger.info("Connection Successful.")
         except psycopg2.OperationalError as e:
             logger.info(f"Could not connect to Database: {e}")


### PR DESCRIPTION
Very simple change to raise the max number of connections our connection pool in pythin can have now that we have initialized pgbouncer to do the real pooling behind the scenes (maxconn in python now represents max length of the 'queue' per worker)

Closes: [#514](https://github.com/bcgov/nr-bcwat/issues/514)