### PR TITLE
swap in lake name

### DIFF
--- a/client/src/components/watershed/Watershed.vue
+++ b/client/src/components/watershed/Watershed.vue
@@ -411,6 +411,13 @@ const openReport = async () => {
     reportContent.value = await getWatershedReportByWFI(watershedInfo.value.wfi);
     loading.value = false;
     if (reportContent.value) {
+
+        // The below lines of code address an issue with lakes, the watershed report is generated for the upstream most point of the stream that flows out of the lake but the report is still meant to represent the lake. Therefore, we set the watershed name in the report overview to be the name of the lake instead of the river it was generated for. We also ensure that the lake name is included in the bus stop names for the report (the if statment is to not double add it for the normal case on rivers where it is already included).
+        reportContent.value.overview.watershedName = watershedInfo.value.name;
+        if (!reportContent.value.overview.busStopNames.includes(watershedInfo.value.name)) {
+            reportContent.value.overview.busStopNames.unshift(watershedInfo.value.name);
+        }
+
         reportOpen.value = true;
     }
 };


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Small change to swap the name for lakes. There is another option to change how the bakcend makes the reports by taking the 'sliding down the lake' logic out of the first query which returns the wfi and instread into the 2nd query that takes a wfi. Figured this was a simpler change but if you think the other more involved change is better let me know, I know its a bit strange to be doing this kind of data manipulation on the FE (hence the comment)

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)

<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Closes [#517](https://github.com/bcgov/nr-bcwat/issues/517)