### PR TITLE
Use managment basin name in reports

### DIFF
--- a/backend/routers/watershed.py
+++ b/backend/routers/watershed.py
@@ -195,6 +195,9 @@ def get_watershed_report_by_id(id):
     if(not "watershed_metadata" in watershed_metadata.keys() or watershed_metadata["watershed_metadata"] is None):
         return response, 404
 
+    if watershed_metadata["watershed_metadata"]["downstream_gnis_name"] == watershed_metadata["watershed_name"]:
+        watershed_metadata["watershed_metadata"]["downstream_gnis_name"] += " (Downstream)"
+
     response["overview"] = {
           "watershedName": watershed_metadata["watershed_name"],
           "busStopNames": [bus_stop['name'] for bus_stop in bus_stops],

--- a/backend/tests/unit/fixtures/watershed/watershed9253853ReportData.json
+++ b/backend/tests/unit/fixtures/watershed/watershed9253853ReportData.json
@@ -853,7 +853,7 @@
     "max_elev": null,
     "mgmt_lat": 49.6991162102478,
     "mgmt_lng": -117.464174059187,
-    "mgmt_name": "Lemon Creek",
+    "mgmt_name": "Lemon Creek (Downstream)",
     "mgmt_polygon": {
       "coordinates": [
         [

--- a/client/src/components/watershed/report/AnnualHydrology.vue
+++ b/client/src/components/watershed/report/AnnualHydrology.vue
@@ -9,7 +9,7 @@
                 watershed associated with the next downstream confluence<NoteLink
                     :note-number="2"
                 />
-                ({{ props.reportContent.overview.watershedName }} (Downstream)) has
+                ({{ props.reportContent.overview.mgmt_name }} has
                 also been outlined in purple, with summary statistics for both
                 watersheds provided in the table below. Please note that all values
                 presented are estimates and are subject to error<NoteLink
@@ -36,7 +36,7 @@
                         <th>Annual Statistics</th>
                         <th>{{ reportContent.overview.watershedName }}</th>
                         <th>
-                            {{ reportContent.overview.watershedName }} (downstream)
+                            {{ reportContent.overview.mgmt_name }}
                         </th>
                     </tr>
                     <tr>

--- a/client/src/components/watershed/report/MonthlyHydrology.vue
+++ b/client/src/components/watershed/report/MonthlyHydrology.vue
@@ -55,7 +55,7 @@
             <div class="monthly-hydrology-header">
                 <MapMarker fill="#1e1436" />
                 <h1>
-                    Monthly Water Supply and Demand - {{ reportContent.overview.watershedName }} (Downstream)
+                    Monthly Water Supply and Demand - {{ reportContent.overview.mgmt_name }}
                 </h1>
             </div>
             <p>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Swapped the frontend to use the management basin name in the report. If the management basin name is the same as the basin name I retained the current behavior of using (Downstream) to differentiate them. I am presently unable to check the existing tools to see if they always include (Downstream) or only when the name is the same because presently the sites are down (same behavior as yesterday). On monday I will check the existing tools and update this PR accordingly

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

<!-- Bug fix (non-breaking change which fixes an issue) -->
New feature (non-breaking change which adds functionality)
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Closes #537 