### PR TITLE
Put lines on top of watershed bar chart

### DIFF
--- a/client/src/components/watershed/report/MonthlyHydrology.vue
+++ b/client/src/components/watershed/report/MonthlyHydrology.vue
@@ -76,6 +76,7 @@
                     <MonthlyHydrologyChart
                         :chart-data="reportContent.downstreamMonthlyHydrology"
                         chart-id="monthly-chart-downstream"
+                        :mad="reportContent.downstreamMonthlyHydrology.meanAnnualDischarge"
                     />
                 </div>
             </div>

--- a/client/src/components/watershed/report/MonthlyHydrologyChart.vue
+++ b/client/src/components/watershed/report/MonthlyHydrologyChart.vue
@@ -122,32 +122,6 @@ onMounted(() => {
     const y = d3.scaleLinear().domain([0, maxY.value]).range([height, 0]);
     svg.value.append("g").call(d3.axisLeft(y));
 
-    // Add mean annual discharge lines
-    const mad = props.chartData.meanAnnualDischarge;
-    svg.value
-        .append("path")
-        .attr("d", d3.line()([[0, y(mad)], [width, y(mad)]]))
-        .attr("stroke", "#ff5722")
-        .attr("stroke-width", 2)
-        .attr("fill", "none")
-        .style("stroke-dasharray", "3, 3");
-
-    svg.value
-        .append("path")
-        .attr("d", d3.line()([[0, y(mad * 0.2)], [width, y(mad * 0.2)]]))
-        .attr("stroke", "#ff9800")
-        .attr("stroke-width", 2)
-        .attr("fill", "none")
-        .style("stroke-dasharray", "3, 3");
-
-    svg.value
-        .append("path")
-        .attr("d", d3.line()([[0, y(mad * 0.1)], [width, y(mad * 0.1)]]))
-        .attr("stroke", "#ffc107")
-        .attr("stroke-width", 2)
-        .attr("fill", "none")
-        .style("stroke-dasharray", "3, 3");
-
     // Set colours for data
     const color = d3
         .scaleOrdinal()
@@ -184,6 +158,33 @@ onMounted(() => {
         .attr("fill", '#ffffff00')
         .attr("stroke", 'black')
         .attr("stroke-width", "2px")
+
+    // Add mean annual discharge lines
+    const mad = props.chartData.meanAnnualDischarge;
+    svg.value
+        .append("path")
+        .attr("d", d3.line()([[0, y(mad)], [width, y(mad)]]))
+        .attr("stroke", "#ff5722")
+        .attr("stroke-width", 2)
+        .attr("fill", "none")
+        .style("stroke-dasharray", "3, 3");
+
+    svg.value
+        .append("path")
+        .attr("d", d3.line()([[0, y(mad * 0.2)], [width, y(mad * 0.2)]]))
+        .attr("stroke", "#ff9800")
+        .attr("stroke-width", 2)
+        .attr("fill", "none")
+        .style("stroke-dasharray", "3, 3");
+
+    svg.value
+        .append("path")
+        .attr("d", d3.line()([[0, y(mad * 0.1)], [width, y(mad * 0.1)]]))
+        .attr("stroke", "#ffc107")
+        .attr("stroke-width", 2)
+        .attr("fill", "none")
+        .style("stroke-dasharray", "3, 3");
+
 
     bindTooltipHandlers();
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

I added the mean annual discharge (mad) lines on top of the bar chart in the watershed report and also we weren't passing in the mad for the downstream monthly hydrology.
<!-- Why is this change required? What problem does it solve? -->
https://github.com/bcgov/nr-bcwat/issues/549


## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->