### PR TITLE
added some limits to pgbackrest job

### DIFF
--- a/charts/openshift/crunchy/templates/PostgresCluster.yaml
+++ b/charts/openshift/crunchy/templates/PostgresCluster.yaml
@@ -166,15 +166,21 @@ spec:
             requests:
               cpu: {{ .Values.crunchy.pgBackRest.sidecars.requests.cpu }}
               memory: {{ .Values.crunchy.pgBackRest.sidecars.requests.memory }}
+            limits:
+              memory: {{ .Values.crunchy.pgBackRest.sidecars.limits.memory }}
         pgbackrestConfig:
           resources:
             requests:
               cpu: {{ .Values.crunchy.pgBackRest.sidecars.requests.cpu }}
               memory: {{ .Values.crunchy.pgBackRest.sidecars.requests.memory }}
+            limits:
+              memory: {{ .Values.crunchy.pgBackRest.sidecars.limits.memory }}
       jobs:
         resources:
           requests:
             cpu: {{ .Values.crunchy.pgBackRest.jobs.requests.cpu }}
+            memory: {{ .Values.crunchy.pgBackRest.jobs.requests.memory }}
+          limits:
             memory: {{ .Values.crunchy.pgBackRest.jobs.requests.memory }}
   {{- end }}
   patroni:

--- a/charts/openshift/crunchy/values.prod.yaml
+++ b/charts/openshift/crunchy/values.prod.yaml
@@ -70,6 +70,8 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       requests:
         cpu: 5m
         memory: 16Mi
+      limits:
+        memory: 1Gi
     jobs:
       requests:
         cpu: 20m


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Added some limits to the pgbackrest job so we wouldn't have a huge spike in memory as we saw before. We were able to manually run a incremental and full backup and both worked in reasonable amounts of time.
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->
