### PR TITLE
Remove outline from existing allocations chart. Change chart maximum

### DIFF
--- a/client/src/components/ReportChart.vue
+++ b/client/src/components/ReportChart.vue
@@ -959,7 +959,7 @@ const setAxisY = () => {
         currentMin = d3.min(props.chartData.map(el => el.min));
         scaleY.value = d3.scaleLinear().range([0, height]).domain([currentMin, currentMax]);
     } else {
-        scaleY.value = d3.scaleLinear().range([height, 0]).domain([currentMin, currentMax * 2]);
+        scaleY.value = d3.scaleLinear().range([height, 0]).domain([currentMin, currentMax * 1.05]);
     }
 };
 

--- a/client/src/components/watershed/report/MonthlyHydrologyChart.vue
+++ b/client/src/components/watershed/report/MonthlyHydrologyChart.vue
@@ -139,7 +139,6 @@ onMounted(() => {
         .data(stackedData)
         .join("g")
         .attr("fill", (d) => color(d.key))
-        .attr("stroke", "black")
         .selectAll("rect")
         .data((d) => d)
         .join("rect")


### PR DESCRIPTION
Remove the outlines from the MAD bars so that the existing allocations are easier to see
Reduce the maximum size of d3 charts to be 1% higher than the maximum rather than 100% higher