### PR TITLE
removing schema spy as it auto-fails

### DIFF
--- a/.github/workflows/scheduled.yml
+++ b/.github/workflows/scheduled.yml
@@ -55,13 +55,6 @@ jobs:
               fi
             done
 
-  # https://github.com/bcgov/quickstart-openshift-helpers
-  schema-spy:
-    name: SchemaSpy
-    permissions:
-      contents: write
-    uses: bcgov/quickstart-openshift-helpers/.github/workflows/.schema-spy.yml@v0.9.0
-
   # Run sequentially to reduce chances of rate limiting
   zap:
     name: ZAP Scans


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

Removing schemaSpy from the github action that is scheduled to run once a week. It has been consistently failing as its local DB it spins up does not have the context of our restored db and therefore it fails to run the flyway migrations on it. I don't think it's worth the effort to try and make work as we already have detailed db documentation. Please let me know if we need to keep it Liam!
<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->