### PR TITLE
Move init block into webserver (retain logs to debug if migrations fail)

### DIFF
--- a/charts/okd/airflow/values.yaml
+++ b/charts/okd/airflow/values.yaml
@@ -48,30 +48,6 @@ migrateDatabaseJob:
   env:
     - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
       value: "False"
-  extraInitContainers:
-    - name: bcwat-api-init
-      image: "{{ .Values.migrations.image }}"
-      imagePullPolicy: Always
-      env:
-      - name: FLYWAY_URL
-        valueFrom:
-          secretKeyRef:
-            name: bcwat-db-pguser-bcwat-api-admin
-            key: jdbc-uri
-      - name: FLYWAY_USER
-        valueFrom:
-          secretKeyRef:
-            name: bcwat-db-pguser-bcwat-api-admin
-            key: user
-      - name: FLYWAY_PASSWORD
-        valueFrom:
-          secretKeyRef:
-            name: bcwat-db-pguser-bcwat-api-admin
-            key: password
-      resources:
-        requests:
-          cpu: 50m
-          memory: 75Mi
   securityContext:
     runAsNonRoot: true
     seccompProfile:
@@ -114,6 +90,30 @@ webserver:
   env:
     - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
       value: "False"
+  extraInitContainers:
+    - name: bcwat-api-init
+      image: "{{ .Values.migrations.image }}"
+      imagePullPolicy: Always
+      env:
+      - name: FLYWAY_URL
+        valueFrom:
+          secretKeyRef:
+            name: bcwat-db-pguser-bcwat-api-admin
+            key: jdbc-uri
+      - name: FLYWAY_USER
+        valueFrom:
+          secretKeyRef:
+            name: bcwat-db-pguser-bcwat-api-admin
+            key: user
+      - name: FLYWAY_PASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: bcwat-db-pguser-bcwat-api-admin
+            key: password
+      resources:
+        requests:
+          cpu: 50m
+          memory: 75Mi
   waitForMigrations:
     enabled: false
   securityContext:

--- a/charts/openshift/airflow/values.dev.yaml
+++ b/charts/openshift/airflow/values.dev.yaml
@@ -53,26 +53,6 @@ webserver:
   env:
     - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
       value: "False"
-  waitForMigrations:
-    enabled: false
-  securityContext:
-    runAsUser: 1018340000
-    fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
-
-scheduler:
-  env:
-    - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
-      value: "False"
-  waitForMigrations:
-    enabled: false
-  securityContext:
-    runAsUser: 1018340000
-    fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
-
-migrateDatabaseJob:
-  env:
-    - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
-      value: "False"
   extraInitContainers:
     - name: flyway-migrations
       image: "ghcr.io/bcgov/nr-bcwat/airflow/migrations:{{ .Values.images.airflow.tag }}"
@@ -105,6 +85,26 @@ migrateDatabaseJob:
         requests:
           cpu: 50m
           memory: 75Mi
+  waitForMigrations:
+    enabled: false
+  securityContext:
+    runAsUser: 1018340000
+    fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
+
+scheduler:
+  env:
+    - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
+      value: "False"
+  waitForMigrations:
+    enabled: false
+  securityContext:
+    runAsUser: 1018340000
+    fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
+
+migrateDatabaseJob:
+  env:
+    - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
+      value: "False"
   securityContext:
     runAsUser: 1018340000
     fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)

--- a/charts/openshift/airflow/values.prod.yaml
+++ b/charts/openshift/airflow/values.prod.yaml
@@ -53,26 +53,6 @@ webserver:
   env:
     - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
       value: "False"
-  waitForMigrations:
-    enabled: false
-  securityContext:
-    runAsUser: 1017940000
-    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
-
-scheduler:
-  env:
-    - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
-      value: "False"
-  waitForMigrations:
-    enabled: false
-  securityContext:
-    runAsUser: 1017940000
-    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
-
-migrateDatabaseJob:
-  env:
-    - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
-      value: "False"
   extraInitContainers:
     - name: flyway-migrations
       image: "ghcr.io/bcgov/nr-bcwat/airflow/migrations:{{ .Values.images.airflow.tag }}"
@@ -105,6 +85,26 @@ migrateDatabaseJob:
         requests:
           cpu: 50m
           memory: 75Mi
+  waitForMigrations:
+    enabled: false
+  securityContext:
+    runAsUser: 1017940000
+    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
+
+scheduler:
+  env:
+    - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
+      value: "False"
+  waitForMigrations:
+    enabled: false
+  securityContext:
+    runAsUser: 1017940000
+    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
+
+migrateDatabaseJob:
+  env:
+    - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
+      value: "False"
   securityContext:
     runAsUser: 1017940000
     fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)

--- a/charts/openshift/airflow/values.test.yaml
+++ b/charts/openshift/airflow/values.test.yaml
@@ -53,26 +53,6 @@ webserver:
   env:
     - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
       value: "False"
-  waitForMigrations:
-    enabled: false
-  securityContext:
-    runAsUser: 1017950000
-    fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
-
-scheduler:
-  env:
-    - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
-      value: "False"
-  waitForMigrations:
-    enabled: false
-  securityContext:
-    runAsUser: 1017950000
-    fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
-
-migrateDatabaseJob:
-  env:
-    - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
-      value: "False"
   extraInitContainers:
     - name: flyway-migrations
       image: "ghcr.io/bcgov/nr-bcwat/airflow/migrations:{{ .Values.images.airflow.tag }}"
@@ -105,6 +85,26 @@ migrateDatabaseJob:
         requests:
           cpu: 50m
           memory: 75Mi
+  waitForMigrations:
+    enabled: false
+  securityContext:
+    runAsUser: 1017950000
+    fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
+
+scheduler:
+  env:
+    - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
+      value: "False"
+  waitForMigrations:
+    enabled: false
+  securityContext:
+    runAsUser: 1017950000
+    fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
+
+migrateDatabaseJob:
+  env:
+    - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
+      value: "False"
   securityContext:
     runAsUser: 1017950000
     fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)


### PR DESCRIPTION
# Description

Move the ExtraInitContainers block into the webserver block - this is just so logs will retain and it will be easier to debug as the webserver is long running, whereas the migrateDatabaseJob does not retain logs.