### PR TITLE
Needed to update so ENV is parsed top level

### DIFF
--- a/airflow/README.md
+++ b/airflow/README.md
@@ -32,6 +32,10 @@ from datetime import datetime
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 # Executor config with a pod template file and optional override
 # Does not prevent running locally
@@ -45,7 +49,7 @@ from shared.functions import generate_executor_config_template
 )
 def k8s_hello_world_dag():
 
-    @task(executor_config=generate_executor_config_template('tiny'))
+    @task(executor_config=generate_executor_config_template('tiny', ENVIRONMENT))
     def say_hello():
         print("Hello from TaskFlow!")
 

--- a/airflow/dags/asp_dag.py
+++ b/airflow/dags/asp_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="asp_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_asp_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('medium'),
+        executor_config=generate_executor_config_template('medium', ENVIRONMENT),
         task_id="asp_scraper"
     )
     def run_asp(**kwargs):

--- a/airflow/dags/ec_xml_dag.py
+++ b/airflow/dags/ec_xml_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="ec_xml_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_ec_xml_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('tiny'),
+        executor_config=generate_executor_config_template('tiny', ENVIRONMENT),
         task_id="ec_xml_scraper"
     )
     def run_ec_xml(**kwargs):

--- a/airflow/dags/env_aqn_dag.py
+++ b/airflow/dags/env_aqn_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="env_aqn_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_env_aqn_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('tiny'),
+        executor_config=generate_executor_config_template('tiny', ENVIRONMENT),
         task_id="env_aqn_scraper"
     )
     def run_env_aqn(**kwargs):

--- a/airflow/dags/env_hydro_dag.py
+++ b/airflow/dags/env_hydro_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="env_hydro_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_env_hydro_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('medium'),
+        executor_config=generate_executor_config_template('medium', ENVIRONMENT),
         task_id="env_hydro_scraper"
     )
     def run_env_hydro(**kwargs):

--- a/airflow/dags/flnro_dag.py
+++ b/airflow/dags/flnro_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="flnro_wmb_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_flnro_wmb_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('tiny'),
+        executor_config=generate_executor_config_template('tiny', ENVIRONMENT),
         task_id="flnro_wmb_scraper"
     )
     def run_flnro_wmb(**kwargs):

--- a/airflow/dags/flow_works_dag.py
+++ b/airflow/dags/flow_works_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="flowworks_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_flowworks_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('tiny'),
+        executor_config=generate_executor_config_template('tiny', ENVIRONMENT),
         task_id="flowworks_scraper"
     )
     def run_flowworks(**kwargs):

--- a/airflow/dags/gw_moe_dag.py
+++ b/airflow/dags/gw_moe_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="gw_moe_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_gw_moe_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('medium'),
+        executor_config=generate_executor_config_template('medium', ENVIRONMENT),
         task_id="gw_moe_scraper"
     )
     def run_gw_moe(**kwargs):

--- a/airflow/dags/msp_dag.py
+++ b/airflow/dags/msp_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="msp_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_msp_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('tiny'),
+        executor_config=generate_executor_config_template('tiny', ENVIRONMENT),
         task_id="msp_scraper"
     )
     def run_msp(**kwargs):

--- a/airflow/dags/quarterly_climate_ec_update_dag.py
+++ b/airflow/dags/quarterly_climate_ec_update_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="quarterly_ec_update_dag",
@@ -16,7 +20,7 @@ from shared.functions import generate_executor_config_template
 def run_quarterly_ec_update_dag():
 
     @task(
-        executor_config=generate_executor_config_template('medium'),
+        executor_config=generate_executor_config_template('medium', ENVIRONMENT),
         task_id="quarterly_ec_update"
     )
     def run_quarterly_ec_update(**kwargs):

--- a/airflow/dags/quarterly_ems_water_quality_dag.py
+++ b/airflow/dags/quarterly_ems_water_quality_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="quarterly_ems_water_quality_dag",
@@ -16,7 +20,7 @@ from shared.functions import generate_executor_config_template
 def run_quarterly_ems_water_quality_dag():
 
     @task(
-        executor_config=generate_executor_config_template('largest'),
+        executor_config=generate_executor_config_template('largest', ENVIRONMENT),
         task_id="quarterly_ems_water_quality"
     )
     def run_quarterly_ems_water_quality(**kwargs):

--- a/airflow/dags/quarterly_gw_moe_dag.py
+++ b/airflow/dags/quarterly_gw_moe_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="quarterly_moe_gw_update",
@@ -16,7 +20,7 @@ from shared.functions import generate_executor_config_template
 def run_quarterly_gw_moe_update_dag():
 
     @task(
-        executor_config=generate_executor_config_template('medium'),
+        executor_config=generate_executor_config_template('medium', ENVIRONMENT),
         task_id="quarterly_gw_moe_update"
     )
     def run_quarterly_gw_moe_update(**kwargs):
@@ -39,7 +43,7 @@ def run_quarterly_gw_moe_update_dag():
         gw_quarterly_scraper.clean_up()
 
     @task(
-        executor_config=generate_executor_config_template('medium'),
+        executor_config=generate_executor_config_template('medium', ENVIRONMENT),
         task_id="daily_gw_moe_update"
     )
     def run_daily_gw_moe(**kwargs):

--- a/airflow/dags/quarterly_hydat_import_dag.py
+++ b/airflow/dags/quarterly_hydat_import_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="quarterly_hydat_dag",
@@ -18,7 +22,7 @@ from shared.functions import generate_executor_config_template
 def run_quarterly_hydat_import_dag():
 
     @task(
-        executor_config=generate_executor_config_template('heavy'),
+        executor_config=generate_executor_config_template('heavy', ENVIRONMENT),
         task_id="quarterly_hydat_import"
     )
     def run_quarterly_hydat_import(**kwargs):

--- a/airflow/dags/quarterly_moe_hydrometric_historic_dag.py
+++ b/airflow/dags/quarterly_moe_hydrometric_historic_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="quarterly_moe_hydrometric_historic_update_dag",
@@ -16,7 +20,7 @@ from shared.functions import generate_executor_config_template
 def run_quarterly_moe_hydrometric_historic_update_dag():
 
     @task(
-        executor_config=generate_executor_config_template('heavy'),
+        executor_config=generate_executor_config_template('heavy', ENVIRONMENT),
         task_id="quarterly_moe_hydrometric_hitoric_update_discharge"
     )
     def run_quarterly_moe_hydrometric_historic_update(**kwargs):
@@ -39,7 +43,7 @@ def run_quarterly_moe_hydrometric_historic_update_dag():
         moe_hydro_hist_scraper.load_data()
 
     @task(
-        executor_config=generate_executor_config_template('heavy'),
+        executor_config=generate_executor_config_template('heavy', ENVIRONMENT),
         task_id="daily_moe_hydrometric_historic_update_stage"
     )
     def run_daily_moe_hydrometric_historic(**kwargs):

--- a/airflow/dags/quarterly_water_quality_eccc_dag.py
+++ b/airflow/dags/quarterly_water_quality_eccc_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="quarterly_water_quality_eccc_dag",
@@ -16,7 +20,7 @@ from shared.functions import generate_executor_config_template
 def run_quarterly_water_quality_eccc_dag():
 
     @task(
-        executor_config=generate_executor_config_template('medium'),
+        executor_config=generate_executor_config_template('medium', ENVIRONMENT),
         task_id="quarterly_water_quality_eccc"
     )
     def run_quarterly_water_quality_eccc(**kwargs):

--- a/airflow/dags/update_station_year_var_status_dag.py
+++ b/airflow/dags/update_station_year_var_status_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="update_station_year_var_status_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_update_year_var_status_dag():
 
     @task(
-        executor_config=generate_executor_config_template('tiny'),
+        executor_config=generate_executor_config_template('tiny', ENVIRONMENT),
         task_id="variable_update"
     )
     def run_update_variable():
@@ -28,7 +32,7 @@ def run_update_year_var_status_dag():
         update_station_variable_table(conn)
 
     @task(
-        executor_config=generate_executor_config_template('tiny'),
+        executor_config=generate_executor_config_template('tiny', ENVIRONMENT),
         task_id="year_update"
     )
     def run_update_year():
@@ -41,7 +45,7 @@ def run_update_year_var_status_dag():
         update_station_year_table(conn)
 
     @task(
-        executor_config=generate_executor_config_template('tiny'),
+        executor_config=generate_executor_config_template('tiny', ENVIRONMENT),
         task_id="status_update"
     )
     def run_update_station_status():

--- a/airflow/dags/water_approval_dag.py
+++ b/airflow/dags/water_approval_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="wls_water_approval_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_water_approval_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('small'),
+        executor_config=generate_executor_config_template('small', ENVIRONMENT),
         task_id="water_approval_scraper"
     )
     def run_water_approval(**kwargs):

--- a/airflow/dags/water_licences_bcer_dag.py
+++ b/airflow/dags/water_licences_bcer_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="bc_ogc_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_short_term_approval_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('tiny'),
+        executor_config=generate_executor_config_template('tiny', ENVIRONMENT),
         task_id="short_term_approval_scraper"
     )
     def run_short_term_approval(**kwargs):

--- a/airflow/dags/weather_farm_prd_dag.py
+++ b/airflow/dags/weather_farm_prd_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="weather_farm_prd_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_weather_farm_prd_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('tiny'),
+        executor_config=generate_executor_config_template('tiny', ENVIRONMENT),
         task_id="weather_farm_prd_scraper"
     )
     def run_weather_farm_prd(**kwargs):

--- a/airflow/dags/wra_wrl_dag.py
+++ b/airflow/dags/wra_wrl_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="wra_wrl_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_wra_wrl_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('medium'),
+        executor_config=generate_executor_config_template('medium', ENVIRONMENT),
         task_id="wra_scraper"
     )
     def run_wra(**kwargs):
@@ -34,7 +38,7 @@ def run_wra_wrl_scraper():
         wra_scraper.load_data()
 
     @task(
-        executor_config=generate_executor_config_template('medium'),
+        executor_config=generate_executor_config_template('medium', ENVIRONMENT),
         task_id="wrl_scraper"
     )
     def run_wrl(**kwargs):
@@ -53,7 +57,7 @@ def run_wra_wrl_scraper():
         wrl_scraper.load_data()
 
     @task(
-        executor_config=generate_executor_config_template('medium'),
+        executor_config=generate_executor_config_template('medium', ENVIRONMENT),
         task_id="combined_and_load",
         trigger_rule="all_success"
     )

--- a/airflow/dags/wsc_hydro_dag.py
+++ b/airflow/dags/wsc_hydro_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="wsc_hydro_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_wsc_hydro_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('medium'),
+        executor_config=generate_executor_config_template('medium', ENVIRONMENT),
         task_id="wsc_hydro_scraper"
     )
     def run_wsc_hydro(**kwargs):

--- a/airflow/shared/constants.py
+++ b/airflow/shared/constants.py
@@ -1,9 +1,3 @@
-import os
-from dotenv import load_dotenv, find_dotenv
-load_dotenv(find_dotenv())
-
-ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
-
 # Map environments to template files
 SUBJECT_TEMPLATES = {
     'OKD': '/opt/airflow/email_templates/subject/okd_subject.html',

--- a/airflow/shared/functions.py
+++ b/airflow/shared/functions.py
@@ -2,21 +2,20 @@
 from airflow.settings import AIRFLOW_HOME
 from kubernetes.client import models as k8s
 from shared.constants import (
-    ENVIRONMENT,
     SUBJECT_TEMPLATES,
     POD_TEMPLATES
 )
 
-def generate_executor_config_template(pod_template_type):
-
-    subject_template = SUBJECT_TEMPLATES.get(
-        ENVIRONMENT,
-        '/opt/airflow/email_templates/no_env_subject.html'
-    )
+def generate_executor_config_template(pod_template_type, ENVIRONMENT):
 
     pod_template = POD_TEMPLATES.get(
         pod_template_type,
         "/opt/airflow/pod_templates/medium_task_template.yaml"
+    )
+
+    subject_template = SUBJECT_TEMPLATES.get(
+        ENVIRONMENT,
+        '/opt/airflow/email_templates/no_env_subject.html'
     )
 
     executor_config_template = {

--- a/airflow/unused_dags/drive_bc_dag.py
+++ b/airflow/unused_dags/drive_bc_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="drive_bc_dag",
@@ -15,7 +19,7 @@ from shared.functions import generate_executor_config_template
 def run_drive_bc_scraper():
 
     @task(
-        executor_config=generate_executor_config_template('tiny'),
+        executor_config=generate_executor_config_template('tiny', ENVIRONMENT),
         task_id="drive_bc_scraper"
     )
     def run_drive_bc(**kwargs):

--- a/airflow/unused_dags/hourly_to_daily_dag.py
+++ b/airflow/unused_dags/hourly_to_daily_dag.py
@@ -3,6 +3,10 @@ import pendulum
 from airflow.decorators import dag, task
 from shared.constants import default_args
 from shared.functions import generate_executor_config_template
+from dotenv import load_dotenv, find_dotenv
+load_dotenv(find_dotenv())
+
+ENVIRONMENT = os.getenv('ENVIRONMENT', 'no-env-found')
 
 @dag(
     dag_id="convert_hourly_to_daily_dag",
@@ -14,7 +18,7 @@ from shared.functions import generate_executor_config_template
 def run_hourly_to_daily_converter():
 
     @task(
-        executor_config=generate_executor_config_template('tiny'),
+        executor_config=generate_executor_config_template('tiny', ENVIRONMENT),
         task_id="drive_bc_scraper"
     )
     def run_converter(**kwargs):


### PR DESCRIPTION
Tis needs environment moved to top level so it gets parsed properly - this was incorrect and leading to the env not being set:

```
    env:
        - name: "AIRFLOW_IS_K8S_EXECUTOR_POD"
          value: "True"
        - name: "AIRFLOW__EMAIL__SUBJECT_TEMPLATE"
          value: "/opt/airflow/email_templates/subject/no_env_subject.html"
      image: "foundrymainregistry.azurecr.io/bcwat/airflow:latest"
      name: "base"
 ```
      
 from k8s pod spec.
      
  I hope this works