### PR TITLE
Init PGBouncer for Airflow on BCGov

### DIFF
--- a/charts/openshift/airflow/values.dev.yaml
+++ b/charts/openshift/airflow/values.dev.yaml
@@ -29,7 +29,7 @@ extraSecrets:
   airflow-rw-db-conn:
     type: Opaque
     stringData: |
-      connection: {{ index ((lookup "v1" "Secret" .Release.Namespace "bcwat-dev-crunchy-pguser-bcwat-airflow-read-write").data) "pgbouncer-uri" | b64dec | quote }}
+      connection: {{ index ((lookup "v1" "Secret" .Release.Namespace "bcwat-dev-crunchy-pguser-airflow-metadata-rw").data) "pgbouncer-uri" | b64dec | quote }}
   airflow-sendgrid-default:
     type: Opaque
     stringData: |
@@ -98,7 +98,7 @@ webserver:
           cpu: 50m
           memory: 75Mi
   waitForMigrations:
-    enabled: false
+    enabled: true
   securityContext:
     runAsUser: 1018340000
     fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
@@ -110,7 +110,7 @@ scheduler:
     - name: ENVIRONMENT
       value: DEV
   waitForMigrations:
-    enabled: false
+    enabled: true
   securityContext:
     runAsUser: 1018340000
     fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
@@ -172,7 +172,7 @@ triggerer:
   persistence:
     enabled: false
   waitForMigrations:
-    enabled: false
+    enabled: true
   securityContext:
     runAsUser: 1018340000
     fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)

--- a/charts/openshift/airflow/values.prod.yaml
+++ b/charts/openshift/airflow/values.prod.yaml
@@ -29,7 +29,7 @@ extraSecrets:
   airflow-rw-db-conn:
     type: Opaque
     stringData: |
-      uri: {{ index ((lookup "v1" "Secret" .Release.Namespace "bcwat-prod-crunchy-pguser-bcwat-airflow-read-write").data) "pgbouncer-uri" | b64dec | quote }}
+      connection: {{ index ((lookup "v1" "Secret" .Release.Namespace "bcwat-prod-crunchy-pguser-airflow-metadata-rw").data) "pgbouncer-uri" | b64dec | quote }}
   airflow-sendgrid-default:
     type: Opaque
     stringData: |

--- a/charts/openshift/airflow/values.test.yaml
+++ b/charts/openshift/airflow/values.test.yaml
@@ -29,7 +29,7 @@ extraSecrets:
   airflow-rw-db-conn:
     type: Opaque
     stringData: |
-      uri: {{ index ((lookup "v1" "Secret" .Release.Namespace "bcwat-test-crunchy-pguser-bcwat-airflow-read-write").data) "pgbouncer-uri" | b64dec | quote }}
+      connection: {{ index ((lookup "v1" "Secret" .Release.Namespace "bcwat-test-crunchy-pguser-airflow-metadata-rw").data) "pgbouncer-uri" | b64dec | quote }}
   airflow-sendgrid-default:
     type: Opaque
     stringData: |
@@ -97,7 +97,7 @@ webserver:
           cpu: 50m
           memory: 75Mi
   waitForMigrations:
-    enabled: false
+    enabled: true
   securityContext:
     runAsUser: 1017950000
     fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
@@ -109,7 +109,7 @@ scheduler:
     - name: ENVIRONMENT
       value: TEST
   waitForMigrations:
-    enabled: false
+    enabled: true
   securityContext:
     runAsUser: 1017950000
     fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
@@ -171,7 +171,7 @@ triggerer:
   persistence:
     enabled: false
   waitForMigrations:
-    enabled: false
+    enabled: true
   securityContext:
     runAsUser: 1017950000
     fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)

--- a/charts/openshift/crunchy/values.dev.yaml
+++ b/charts/openshift/crunchy/values.dev.yaml
@@ -145,6 +145,9 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       databases:
         - airflow_metadata
       options: "SUPERUSER CREATEDB CREATEROLE"
+    - name: airflow-metadata-rw
+      databases:
+        - airflow_metadata
     - name: bcwat-api-admin
       databases:
         - bcwat_dev
@@ -155,4 +158,3 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
     - name: bcwat-airflow-read-write
       databases:
         - bcwat_dev
-        - airflow_metadata

--- a/charts/openshift/crunchy/values.prod.yaml
+++ b/charts/openshift/crunchy/values.prod.yaml
@@ -136,6 +136,9 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       databases:
         - airflow_metadata
       options: "SUPERUSER CREATEDB CREATEROLE"
+    - name: airflow-metadata-rw
+      databases:
+        - airflow_metadata
     - name: bcwat-api-admin
       databases:
         - bcwat_prod
@@ -146,4 +149,3 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
     - name: bcwat-airflow-read-write
       databases:
         - bcwat_prod
-        - airflow_metadata

--- a/charts/openshift/crunchy/values.test.yaml
+++ b/charts/openshift/crunchy/values.test.yaml
@@ -144,6 +144,9 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
       databases:
         - airflow_metadata
       options: "SUPERUSER CREATEDB CREATEROLE"
+    - name: airflow-metadata-rw
+      databases:
+        - airflow_metadata
     - name: bcwat-api-admin
       databases:
         - bcwat_dev
@@ -154,4 +157,3 @@ crunchy: # enable it for TEST and PROD, for PR based pipelines simply use single
     - name: bcwat-airflow-read-write
       databases:
         - bcwat_dev
-        - airflow_metadata


### PR DESCRIPTION
# Description

Approved in Dev, initializing PGBouncer user for Airflow Access. This connection string was previously using the bcwat_dev DB hence the issue. 