### PR TITLE
Bcwat 725 quarterly scraper failures

### DIFF
--- a/airflow/dags/quarterly_gw_moe_dag.py
+++ b/airflow/dags/quarterly_gw_moe_dag.py
@@ -40,7 +40,6 @@ def run_quarterly_gw_moe_update_dag():
         gw_quarterly_scraper.validate_downloaded_data()
         gw_quarterly_scraper.transform_data()
         gw_quarterly_scraper.load_data()
-        gw_quarterly_scraper.clean_up()
 
     @task(
         executor_config=generate_executor_config_template('medium', ENVIRONMENT),
@@ -64,7 +63,6 @@ def run_quarterly_gw_moe_update_dag():
         gw_daily_scraper.transform_data()
         gw_daily_scraper.load_data()
         gw_daily_scraper.check_year_in_station_year()
-        gw_daily_scraper.clean_up()
 
     run_quarterly_gw_moe_update() >> run_daily_gw_moe()
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

The Quarterly scraper `quarterly_gw_moe_dag.py` was failing. This was due to the fact that it was looking for a `self.file_path` attribute, when the quarterly version of `gw_moe` doesn't get that attribute.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)

## Further comments

Closes #725 