### PR TITLE
Add Limits to Airflow Services/backend/FE on Openshift

### DIFF
--- a/charts/openshift/airflow/values.dev.yaml
+++ b/charts/openshift/airflow/values.dev.yaml
@@ -68,6 +68,13 @@ webserver:
       value: "False"
     - name: ENVIRONMENT
       value: DEV
+  resources:
+    limits:
+      cpu: 250m
+      memory: 2G
+    requests:
+      cpu: 250m
+      memory: 2G
 
   extraInitContainers:
     - name: flyway-migrations
@@ -101,6 +108,9 @@ webserver:
         requests:
           cpu: 50m
           memory: 75Mi
+        limits:
+          cpu: 50m
+          memory: 75Mi
   waitForMigrations:
     enabled: true
   securityContext:
@@ -113,6 +123,13 @@ scheduler:
       value: "False"
     - name: ENVIRONMENT
       value: DEV
+  resources:
+    limits:
+      cpu: 500m
+      memory: 2G
+    requests:
+      cpu: 500m
+      memory: 2G
   waitForMigrations:
     enabled: true
   securityContext:
@@ -138,6 +155,13 @@ migrateDatabaseJob:
         secretKeyRef:
           name: airflow-migrate-db-conn
           key: connection
+  resources:
+    requests:
+      cpu: 50m
+      memory: 75Mi
+    limits:
+      cpu: 50m
+      memory: 75Mi
   securityContext:
     runAsUser: 1018340000
     fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
@@ -162,6 +186,13 @@ createUserJob:
         secretKeyRef:
           name: airflow-migrate-db-conn
           key: connection
+  resources:
+    requests:
+      cpu: 50m
+      memory: 75Mi
+    limits:
+      cpu: 50m
+      memory: 75Mi
   securityContext:
     runAsUser: 1018340000
     fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
@@ -180,19 +211,22 @@ triggerer:
   securityContext:
     runAsUser: 1018340000
     fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
+  resources:
+    limits:
+      cpu: 250m
+      memory: 1.5G
+    requests:
+      cpu: 250m
+      memory: 1.5G
 
 postgresql:
   enabled: false
-
 flower:
   enabled: false
-
 statsd:
   enabled: false
-
 dags:
   persistence:
     enabled: false
-
 redis:
   enabled: false

--- a/charts/openshift/airflow/values.prod.yaml
+++ b/charts/openshift/airflow/values.prod.yaml
@@ -68,6 +68,13 @@ webserver:
       value: "False"
     - name: ENVIRONMENT
       value: PRODUCTION
+  resources:
+    limits:
+      cpu: 250m
+      memory: 2G
+    requests:
+      cpu: 250m
+      memory: 2G
   extraInitContainers:
     - name: flyway-migrations
       image: "ghcr.io/bcgov/nr-bcwat/migrations:{{ .Values.images.airflow.tag }}"
@@ -100,6 +107,9 @@ webserver:
         requests:
           cpu: 50m
           memory: 75Mi
+        limits:
+          cpu: 50m
+          memory: 75Mi
   waitForMigrations:
     enabled: true
   securityContext:
@@ -112,6 +122,13 @@ scheduler:
       value: "False"
     - name: ENVIRONMENT
       value: PRODUCTION
+  resources:
+    limits:
+      cpu: 500m
+      memory: 2G
+    requests:
+      cpu: 500m
+      memory: 2G
   waitForMigrations:
     enabled: true
   securityContext:
@@ -137,6 +154,13 @@ migrateDatabaseJob:
         secretKeyRef:
           name: airflow-migrate-db-conn
           key: connection
+  resources:
+    requests:
+      cpu: 50m
+      memory: 75Mi
+    limits:
+      cpu: 50m
+      memory: 75Mi
   securityContext:
     runAsUser: 1017940000
     fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
@@ -161,6 +185,13 @@ createUserJob:
         secretKeyRef:
           name: airflow-migrate-db-conn
           key: connection
+  resources:
+    requests:
+      cpu: 50m
+      memory: 75Mi
+    limits:
+      cpu: 50m
+      memory: 75Mi
   securityContext:
     runAsUser: 1017940000
     fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
@@ -175,6 +206,13 @@ triggerer:
       value: "False"
     - name: ENVIRONMENT
       value: PRODUCTION
+  resources:
+    limits:
+      cpu: 250m
+      memory: 1.5G
+    requests:
+      cpu: 250m
+      memory: 1.5G
   persistence:
     enabled: false
   waitForMigrations:

--- a/charts/openshift/airflow/values.test.yaml
+++ b/charts/openshift/airflow/values.test.yaml
@@ -68,6 +68,13 @@ webserver:
       value: "False"
     - name: ENVIRONMENT
       value: TEST
+  resources:
+    limits:
+      cpu: 250m
+      memory: 2G
+    requests:
+      cpu: 250m
+      memory: 2G
   extraInitContainers:
     - name: flyway-migrations
       image: "ghcr.io/bcgov/nr-bcwat/migrations:{{ .Values.images.airflow.tag }}"
@@ -112,6 +119,13 @@ scheduler:
       value: "False"
     - name: ENVIRONMENT
       value: TEST
+  resources:
+    limits:
+      cpu: 500m
+      memory: 2G
+    requests:
+      cpu: 500m
+      memory: 2G
   waitForMigrations:
     enabled: true
   securityContext:
@@ -137,6 +151,13 @@ migrateDatabaseJob:
         secretKeyRef:
           name: airflow-migrate-db-conn
           key: connection
+  resources:
+    requests:
+      cpu: 50m
+      memory: 75Mi
+    limits:
+      cpu: 50m
+      memory: 75Mi
   securityContext:
     runAsUser: 1017950000
     fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
@@ -161,6 +182,13 @@ createUserJob:
         secretKeyRef:
           name: airflow-migrate-db-conn
           key: connection
+  resources:
+    requests:
+      cpu: 50m
+      memory: 75Mi
+    limits:
+      cpu: 50m
+      memory: 75Mi
   securityContext:
     runAsUser: 1017950000
     fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
@@ -172,6 +200,13 @@ triggerer:
       value: "False"
     - name: ENVIRONMENT
       value: TEST
+  resources:
+    limits:
+      cpu: 250m
+      memory: 1.5G
+    requests:
+      cpu: 250m
+      memory: 1.5G
   persistence:
     enabled: false
   waitForMigrations:

--- a/charts/openshift/app/templates/backend/templates/deployment.yaml
+++ b/charts/openshift/app/templates/backend/templates/deployment.yaml
@@ -66,10 +66,10 @@ spec:
           resources: # this is optional
             requests:
               cpu: 750m
-              limits: 1.5G
+              memory: 1.5G
             limits:
               cpu: 750m
-              limits: 1.5G
+              memory: 1.5G
           volumeMounts:
             - mountPath: "/tmp"
               name: tmp

--- a/charts/openshift/app/templates/backend/templates/deployment.yaml
+++ b/charts/openshift/app/templates/backend/templates/deployment.yaml
@@ -65,8 +65,11 @@ spec:
             timeoutSeconds: 5
           resources: # this is optional
             requests:
-              cpu: 50m
-              memory: 75Mi
+              cpu: 750m
+              limits: 1.5G
+            limits:
+              cpu: 750m
+              limits: 1.5G
           volumeMounts:
             - mountPath: "/tmp"
               name: tmp

--- a/charts/openshift/app/templates/frontend/templates/deployment.yaml
+++ b/charts/openshift/app/templates/frontend/templates/deployment.yaml
@@ -66,7 +66,10 @@ spec:
           resources:
             requests:
               cpu: 30m
-              memory: 50Mi
+              memory: 150Mi
+            limits:
+              cpu: 30m
+              memory: 150Mi
           volumeMounts:
             - name: data
               mountPath: /data

--- a/charts/openshift/app/templates/frontend/templates/deployment.yaml
+++ b/charts/openshift/app/templates/frontend/templates/deployment.yaml
@@ -66,10 +66,10 @@ spec:
           resources:
             requests:
               cpu: 30m
-              memory: 150Mi
+              memory: 50Mi
             limits:
               cpu: 30m
-              memory: 150Mi
+              memory: 50Mi
           volumeMounts:
             - name: data
               mountPath: /data


### PR DESCRIPTION
# Description

Add Limits to our Openshift Airflow/Api/FrontEnd Pods. 

These values were gathered by looking at the resource usage across upper each pod and providing more than what has ever been used, just to ensure this does not disrupt the health of our namespaces up to this point.