### PR TITLE
Webserver liveness probe

### DIFF
--- a/charts/okd/airflow/values.yaml
+++ b/charts/okd/airflow/values.yaml
@@ -88,6 +88,12 @@ logs:
     storageClassName: airflow
 
 webserver:
+  livenessProbe:
+    initialDelaySeconds: 60
+  readinessProbe:
+    initialDelaySeconds: 60
+  startupProbe:
+    initialDelaySeconds: 30
   env:
     - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
       value: "False"

--- a/charts/openshift/airflow/values.dev.yaml
+++ b/charts/openshift/airflow/values.dev.yaml
@@ -63,6 +63,12 @@ images:
     pullPolicy: Always
 
 webserver:
+  livenessProbe:
+    initialDelaySeconds: 60
+  readinessProbe:
+    initialDelaySeconds: 60
+  startupProbe:
+    initialDelaySeconds: 30
   env:
     - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
       value: "False"

--- a/charts/openshift/airflow/values.prod.yaml
+++ b/charts/openshift/airflow/values.prod.yaml
@@ -63,6 +63,12 @@ images:
     pullPolicy: Always
 
 webserver:
+  livenessProbe:
+    initialDelaySeconds: 60
+  readinessProbe:
+    initialDelaySeconds: 60
+  startupProbe:
+    initialDelaySeconds: 30
   env:
     - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
       value: "False"

--- a/charts/openshift/airflow/values.test.yaml
+++ b/charts/openshift/airflow/values.test.yaml
@@ -63,6 +63,12 @@ images:
     pullPolicy: Always
 
 webserver:
+  livenessProbe:
+    initialDelaySeconds: 60
+  readinessProbe:
+    initialDelaySeconds: 60
+  startupProbe:
+    initialDelaySeconds: 30
   env:
     - name: AIRFLOW__CORE__DAGS_ARE_PAUSED_AT_CREATION
       value: "False"


### PR DESCRIPTION
# Description

Increase timeouts for Liveness Probe/StartUp Prove/Readiness Probe

We have previously seen a pattern where the webserver gets into a crashloop back off, as it keeps getting sigkill 15. I believe this is because the startup probe is failing. The default values are below:

```
webserver:
  enabled: true
  # Add custom annotations to the webserver configmap
  configMapAnnotations: {}
  #  hostAliases for the webserver pod
  hostAliases: []
  #  - ip: "127.0.0.1"
  #    hostnames:
  #      - "foo.local"
  #  - ip: "10.1.2.3"
  #    hostnames:
  #      - "foo.remote"
  allowPodLogReading: true
  livenessProbe:
    initialDelaySeconds: 15
    timeoutSeconds: 5
    failureThreshold: 5
    periodSeconds: 10
    scheme: HTTP

  readinessProbe:
    initialDelaySeconds: 15
    timeoutSeconds: 5
    failureThreshold: 5
    periodSeconds: 10
    scheme: HTTP

  # Wait for at most 1 minute (6*10s) for the webserver container to startup.
  # livenessProbe kicks in after the first successful startupProbe
  startupProbe:
    initialDelaySeconds: 0
    timeoutSeconds: 20
    failureThreshold: 6
    periodSeconds: 10
    scheme: HTTP
```

This is from the airflow github: https://github.com/apache/airflow/blob/main/chart/values.yaml

I am upping these values to give the webserver more time to ready itself to begin, and hopefully this leads to less crash loops on initialization for the webserver.