### PR TITLE
Hotfix msp issue

### DIFF
--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/StationObservationPipeline.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/StationObservationPipeline.py
@@ -184,7 +184,8 @@ class StationObservationPipeline(EtlPipeline):
             # Since from here on out the columns will be the stripped ones, if they have changed
             # our schema_overrides from above may not have applied
             # Perform CAST-ing as necessary
-            data_df = data_df.cast(self.expected_dtype[key], strict=False)
+            if(key in self.expected_dtype):
+                data_df = data_df.cast(self.expected_dtype[key], strict=False)
 
             # __downloaded_data contains the path to the downloaded data if go_through_all_stations is False
             if not self.go_through_all_stations:

--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/StationObservationPipeline.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/StationObservationPipeline.py
@@ -181,6 +181,10 @@ class StationObservationPipeline(EtlPipeline):
 
             # Remove any leading or trailing whitespaces:
             data_df = data_df.rename(str.strip)
+            # Since from here on out the columns will be the stripped ones, if they have changed
+            # our schema_overrides from above may not have applied
+            # Perform CAST-ing as necessary
+            data_df = data_df.cast(self.expected_dtype[key], strict=False)
 
             # __downloaded_data contains the path to the downloaded data if go_through_all_stations is False
             if not self.go_through_all_stations:


### PR DESCRIPTION
# Description

When we were getting data for the msp scraper, it would have column headers with whitespace:

`Snow Course Name, Number, Elev. metres, Date of Survey, Snow Depth cm, Water Equiv. mm,  Survey Code, Snow Line Elev. m, Density %, Survey Period`

When these are then loaded from the csv into a polars lf, the schema_overrides are applied based on the headers stripped of whitespace. However, since these are not the current headers the schema isn't applied and therefore the schema can not match and the scraper can fail!

<!-- Why is this change required? What problem does it solve? -->
<!-- If it fixes an open issue, please link to the issue here. -->

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)