### PR TITLE
Excluded ASP from getting type casted in Download

### DIFF
--- a/airflow/etl_pipelines/scrapers/StationObservationPipeline/StationObservationPipeline.py
+++ b/airflow/etl_pipelines/scrapers/StationObservationPipeline/StationObservationPipeline.py
@@ -184,7 +184,7 @@ class StationObservationPipeline(EtlPipeline):
             # Since from here on out the columns will be the stripped ones, if they have changed
             # our schema_overrides from above may not have applied
             # Perform CAST-ing as necessary
-            if(key in self.expected_dtype):
+            if(key in self.expected_dtype and self.name != "ASP"):
                 data_df = data_df.cast(self.expected_dtype[key], strict=False)
 
             # __downloaded_data contains the path to the downloaded data if go_through_all_stations is False


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
# Description

There was a recent fix that went in that added a type cast to the download function. This will break the ASP scraper because there are minor transformations that needs to be done BEFORE the data verification step. I missed this in the PR because ASP is the only scraper that requires this transformation.

## Types of changes

<!-- What types of changes does your code introduce? Uncomment all that apply: -->

Bug fix (non-breaking change which fixes an issue)
<!-- New feature (non-breaking change which adds functionality) -->
<!-- Documentation (non-breaking change with enhancements to documentation) -->
<!-- Breaking change (fix or feature that would cause existing functionality to change) -->

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) doc
- [x] I have checked that unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
