### PR TITLE
Trigger Rebuild - Updated Mapbox Token

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "bc-wat-app",
-    "version": "4.12.1",
+    "version": "4.13.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "bc-wat-app",
-            "version": "4.12.1",
+            "version": "4.13.1",
             "dependencies": {
                 "@bcgov/bc-sans": "^2.1.0",
                 "@quasar/extras": "^1.16.17",

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "bc-wat-app",
     "private": true,
-    "version": "4.13.0",
+    "version": "4.13.1",
     "type": "module",
     "scripts": {
         "dev": "vite",


### PR DESCRIPTION
Testing Functionality of new Mapbox Token - URL restricted.

These values are set as Github Secrets, and the new token should be used immediately on deploy.

The proper one ends in `R-wC6nNA`, and can be inspected via the network tab and `env.js`.