### PR TITLE
Update Config - Airflow Openshift

### DIFF
--- a/.github/workflows/.airflow-deployer.yml
+++ b/.github/workflows/.airflow-deployer.yml
@@ -81,8 +81,11 @@ on:
       airflow_flowworks_username:
         description: Airflow Flowworks Username
         required: true
-      airflow_webserver_secret_key:
-        description: Airflow Webserver Secret Key
+      airflow_api_secret_key:
+        description: Airflow API Secret Key
+        required: true
+      airflow_api_jwt_key:
+        description: Airflow API JWT Key
         required: true
       airflow_sendgrid_api_key:
         description: Airflow Sendgrid API Key
@@ -142,7 +145,7 @@ jobs:
             helm repo update
 
             # Helm upgrade/rollout (release name = airflow)
-            helm upgrade --install airflow apache-airflow/airflow --version 1.16.0 \
+            helm upgrade --install airflow apache-airflow/airflow --version 1.18.0 \
               --wait \
               ${{ inputs.atomic && '--atomic' || '' }} \
               --timeout ${{ inputs['timeout-minutes'] }}m \
@@ -151,7 +154,8 @@ jobs:
               --set-string secrets.bcwatFlowworks.password="${{ secrets.airflow_flowworks_password }}" \
               --set-string secrets.bcwatFlowworks.username="${{ secrets.airflow_flowworks_username }}" \
               --set-string secrets.fernet.key="${{ secrets.airflow_fernet_key }}" \
-              --set-string secrets.webserver.key="${{ secrets.airflow_webserver_secret_key }}" \
+              --set-string secrets.api.secretKey="${{ secrets.airflow_api_secret_key }}" \
+              --set-string secrets.api.jwtKey="${{ secrets.airflow_api_jwt_key }}" \
               --set-string secrets.sendgridApiKey="${{ secrets.airflow_sendgrid_api_key }}" \
               --set migrations.databaseAlias=${{ inputs.db_name }}-crunchy \
               --set migrations.databaseUser=${{ inputs.db_user }} \

--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -48,7 +48,8 @@ jobs:
       airflow_flowworks_password: ${{ secrets.AIRFLOW_FLOWWORKS_PASSWORD }}
       airflow_flowworks_username: ${{ secrets.AIRFLOW_FLOWWORKS_USERNAME }}
       airflow_sendgrid_api_key: ${{ secrets.AIRFLOW_SENDGRID_API_KEY }}
-      airflow_webserver_secret_key: ${{ secrets.AIRFLOW_WEBSERVER_SECRET_KEY }}
+      airflow_api_secret_key: ${{ secrets.AIRFLOW_API_SECRET_KEY }}
+      airflow_api_jwt_key: ${{ secrets.AIRFLOW_API_JWT_KEY }}
     with:
       directory: ./charts/openshift/airflow
       values: values.dev.yaml

--- a/airflow/pod_templates/openshift/heavy_task_template.yaml
+++ b/airflow/pod_templates/openshift/heavy_task_template.yaml
@@ -13,7 +13,7 @@ spec:
   initContainers: []
   containers:
     - name: base
-      image: apache/airflow:2.10.5
+      image: apache/airflow:3.1.7
       imagePullPolicy: Always
       env:
         - name: AIRFLOW__CORE__EXECUTOR
@@ -40,11 +40,16 @@ spec:
             secretKeyRef:
               name: airflow-rw-db-conn
               key: connection
-        - name: AIRFLOW__WEBSERVER__SECRET_KEY
+        - name: AIRFLOW__API__SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: airflow-webserver-secret-key
-              key: webserver-secret-key
+              name: airflow-api-secret-key
+              key: api-secret-key
+        - name: AIRFLOW__API_AUTH__JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: airflow-jwt-secret
+              key: jwt-secret
         - name: AIRFLOW__KUBERNETES__LOGS_SERVICE_HOST
           value: airflow-webserver
         - name: AIRFLOW__KUBERNETES__LOGS_SERVICE_PORT
@@ -77,6 +82,10 @@ spec:
           value: airflow@foundryspatial.com
         - name: AIRFLOW__EMAIL__HTML_CONTENT_TEMPLATE
           value: "/opt/airflow/email_templates/content/openshift_content.html"
+        - name: AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME
+          value: "21600"
+        - name: AIRFLOW__API_AUTH__JWT_LEEWAY
+          value: "60"
       resources:
         requests:
           memory: 4096Mi

--- a/airflow/pod_templates/openshift/largest_task_template.yaml
+++ b/airflow/pod_templates/openshift/largest_task_template.yaml
@@ -13,7 +13,7 @@ spec:
   initContainers: []
   containers:
     - name: base
-      image: apache/airflow:2.10.5
+      image: apache/airflow:3.1.7
       imagePullPolicy: Always
       env:
         - name: AIRFLOW__CORE__EXECUTOR
@@ -40,11 +40,16 @@ spec:
             secretKeyRef:
               name: airflow-rw-db-conn
               key: connection
-        - name: AIRFLOW__WEBSERVER__SECRET_KEY
+        - name: AIRFLOW__API__SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: airflow-webserver-secret-key
-              key: webserver-secret-key
+              name: airflow-api-secret-key
+              key: api-secret-key
+        - name: AIRFLOW__API_AUTH__JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: airflow-jwt-secret
+              key: jwt-secret
         - name: AIRFLOW__KUBERNETES__LOGS_SERVICE_HOST
           value: airflow-webserver
         - name: AIRFLOW__KUBERNETES__LOGS_SERVICE_PORT
@@ -77,6 +82,10 @@ spec:
           value: airflow@foundryspatial.com
         - name: AIRFLOW__EMAIL__HTML_CONTENT_TEMPLATE
           value: "/opt/airflow/email_templates/content/openshift_content.html"
+        - name: AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME
+          value: "21600"
+        - name: AIRFLOW__API_AUTH__JWT_LEEWAY
+          value: "60"
       resources:
         requests:
           memory: 5000Mi

--- a/airflow/pod_templates/openshift/medium_task_template.yaml
+++ b/airflow/pod_templates/openshift/medium_task_template.yaml
@@ -13,7 +13,7 @@ spec:
   initContainers: []
   containers:
     - name: base
-      image: apache/airflow:2.10.5
+      image: apache/airflow:3.1.7
       imagePullPolicy: Always
       env:
         - name: AIRFLOW__CORE__EXECUTOR
@@ -40,11 +40,16 @@ spec:
             secretKeyRef:
               name: airflow-rw-db-conn
               key: connection
-        - name: AIRFLOW__WEBSERVER__SECRET_KEY
+        - name: AIRFLOW__API__SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: airflow-webserver-secret-key
-              key: webserver-secret-key
+              name: airflow-api-secret-key
+              key: api-secret-key
+        - name: AIRFLOW__API_AUTH__JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: airflow-jwt-secret
+              key: jwt-secret
         - name: AIRFLOW__KUBERNETES__LOGS_SERVICE_HOST
           value: airflow-webserver
         - name: AIRFLOW__KUBERNETES__LOGS_SERVICE_PORT
@@ -77,6 +82,10 @@ spec:
           value: airflow@foundryspatial.com
         - name: AIRFLOW__EMAIL__HTML_CONTENT_TEMPLATE
           value: "/opt/airflow/email_templates/content/openshift_content.html"
+        - name: AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME
+          value: "21600"
+        - name: AIRFLOW__API_AUTH__JWT_LEEWAY
+          value: "60"
       resources:
         requests:
           memory: 2048Mi

--- a/airflow/pod_templates/openshift/small_task_template.yaml
+++ b/airflow/pod_templates/openshift/small_task_template.yaml
@@ -13,7 +13,7 @@ spec:
   initContainers: []
   containers:
     - name: base
-      image: apache/airflow:2.10.5
+      image: apache/airflow:3.1.7
       imagePullPolicy: Always
       env:
         - name: AIRFLOW__CORE__EXECUTOR
@@ -40,11 +40,16 @@ spec:
             secretKeyRef:
               name: airflow-rw-db-conn
               key: connection
-        - name: AIRFLOW__WEBSERVER__SECRET_KEY
+        - name: AIRFLOW__API__SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: airflow-webserver-secret-key
-              key: webserver-secret-key
+              name: airflow-api-secret-key
+              key: api-secret-key
+        - name: AIRFLOW__API_AUTH__JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: airflow-jwt-secret
+              key: jwt-secret
         - name: AIRFLOW__KUBERNETES__LOGS_SERVICE_HOST
           value: airflow-webserver
         - name: AIRFLOW__KUBERNETES__LOGS_SERVICE_PORT
@@ -77,6 +82,10 @@ spec:
           value: airflow@foundryspatial.com
         - name: AIRFLOW__EMAIL__HTML_CONTENT_TEMPLATE
           value: "/opt/airflow/email_templates/content/openshift_content.html"
+        - name: AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME
+          value: "21600"
+        - name: AIRFLOW__API_AUTH__JWT_LEEWAY
+          value: "60"
       resources:
         requests:
           memory: 750Mi

--- a/airflow/pod_templates/openshift/tiny_task_template.yaml
+++ b/airflow/pod_templates/openshift/tiny_task_template.yaml
@@ -13,7 +13,7 @@ spec:
   initContainers: []
   containers:
     - name: base
-      image: apache/airflow:2.10.5
+      image: apache/airflow:3.1.7
       imagePullPolicy: Always
       env:
         - name: AIRFLOW__CORE__EXECUTOR
@@ -40,11 +40,16 @@ spec:
             secretKeyRef:
               name: airflow-rw-db-conn
               key: connection
-        - name: AIRFLOW__WEBSERVER__SECRET_KEY
+        - name: AIRFLOW__API__SECRET_KEY
           valueFrom:
             secretKeyRef:
-              name: airflow-webserver-secret-key
-              key: webserver-secret-key
+              name: airflow-api-secret-key
+              key: api-secret-key
+        - name: AIRFLOW__API_AUTH__JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: airflow-jwt-secret
+              key: jwt-secret
         - name: AIRFLOW__KUBERNETES__LOGS_SERVICE_HOST
           value: airflow-webserver
         - name: AIRFLOW__KUBERNETES__LOGS_SERVICE_PORT
@@ -77,6 +82,10 @@ spec:
           value: airflow@foundryspatial.com
         - name: AIRFLOW__EMAIL__HTML_CONTENT_TEMPLATE
           value: "/opt/airflow/email_templates/content/openshift_content.html"
+        - name: AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME
+          value: "21600"
+        - name: AIRFLOW__API_AUTH__JWT_LEEWAY
+          value: "60"
       resources:
         requests:
           memory: 500Mi

--- a/charts/openshift/airflow/values.dev.yaml
+++ b/charts/openshift/airflow/values.dev.yaml
@@ -4,9 +4,9 @@ config:
   core:
     min_serialized_dag_update_interval: 300
     min_serialized_dag_fetch_interval: 60
-  scheduler:
-    dag_dir_list_interval: 3600
+  dag_processor:
     min_file_process_interval: 300
+    refresh_interval: 3600
 
 extraSecrets:
   airflow-flowworks-credentials:
@@ -18,10 +18,14 @@ extraSecrets:
     type: Opaque
     stringData: |
       fernet-key: "{{ .Values.secrets.fernet.key }}"
-  airflow-webserver-secret-key:
+  airflow-api-secret-key:
     type: Opaque
     stringData: |
-      webserver-secret-key: "{{ .Values.secrets.webserver.key }}"
+      api-secret-key: "{{ .Values.secrets.api.secretKey }}"
+  airflow-jwt-secret:
+    type: Opaque
+    stringData: |
+      jwt-secret: "{{ .Values.secrets.api.jwtKey }}"
   airflow-migrate-db-conn:
     type: Opaque
     stringData: |
@@ -43,7 +47,8 @@ extraSecrets:
       }'
 
 fernetKeySecretName: airflow-fernet-key
-webserverSecretKeySecretName: airflow-webserver-secret-key
+apiSecretKeySecretName: airflow-api-secret-key
+jwtSecretName: airflow-jwt-secret
 
 data:
   metadataSecretName: airflow-rw-db-conn
@@ -54,7 +59,7 @@ logs:
     storageClassName: netapp-file-standard
     size: 8Gi
 
-airflowVersion: "2.10.5"
+airflowVersion: "3.1.7"
 
 images:
   airflow:
@@ -62,7 +67,11 @@ images:
     tag: latest
     pullPolicy: Always
 
-webserver:
+securityContext:
+  runAsUser: 1018340000
+  fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
+
+apiServer:
   startupProbe:
     timeoutSeconds: 60
   env:
@@ -70,6 +79,10 @@ webserver:
       value: "False"
     - name: ENVIRONMENT
       value: DEV
+    - name: AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME
+      value: "21600"
+    - name: AIRFLOW__API_AUTH__JWT_LEEWAY
+      value: "60"
   resources:
     limits:
       memory: 2G
@@ -110,9 +123,15 @@ webserver:
           memory: 1G
   waitForMigrations:
     enabled: true
-  securityContext:
-    runAsUser: 1018340000
-    fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
+
+dagProcessor:
+  env:
+    - name: ENVIRONMENT
+      value: DEV
+    - name: AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME
+      value: "21600"
+    - name: AIRFLOW__API_AUTH__JWT_LEEWAY
+      value: "60"
 
 scheduler:
   env:
@@ -120,6 +139,10 @@ scheduler:
       value: "False"
     - name: ENVIRONMENT
       value: DEV
+    - name: AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME
+      value: "21600"
+    - name: AIRFLOW__API_AUTH__JWT_LEEWAY
+      value: "60"
   resources:
     limits:
       memory: 2G
@@ -127,9 +150,6 @@ scheduler:
       memory: 2G
   waitForMigrations:
     enabled: true
-  securityContext:
-    runAsUser: 1018340000
-    fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
 
 migrateDatabaseJob:
   env:
@@ -155,9 +175,6 @@ migrateDatabaseJob:
       memory: 1G
     limits:
       memory: 1G
-  securityContext:
-    runAsUser: 1018340000
-    fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
   ttlSecondsAfterFinished: 180
 
 createUserJob:
@@ -184,9 +201,6 @@ createUserJob:
       memory: 1G
     limits:
       memory: 1G
-  securityContext:
-    runAsUser: 1018340000
-    fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
   ttlSecondsAfterFinished: 180
 
 triggerer:
@@ -195,13 +209,14 @@ triggerer:
       value: "False"
     - name: ENVIRONMENT
       value: DEV
+    - name: AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME
+      value: "21600"
+    - name: AIRFLOW__API_AUTH__JWT_LEEWAY
+      value: "60"
   persistence:
     enabled: false
   waitForMigrations:
     enabled: true
-  securityContext:
-    runAsUser: 1018340000
-    fsGroup: 1018340000      # a value within the allowed fsGroup range (1018340000/10000)
   resources:
     limits:
       memory: 1.5G

--- a/charts/openshift/airflow/values.prod.yaml
+++ b/charts/openshift/airflow/values.prod.yaml
@@ -4,9 +4,9 @@ config:
   core:
     min_serialized_dag_update_interval: 300
     min_serialized_dag_fetch_interval: 60
-  scheduler:
-    dag_dir_list_interval: 3600
+  dag_processor:
     min_file_process_interval: 300
+    refresh_interval: 3600
 
 extraSecrets:
   airflow-flowworks-credentials:
@@ -18,10 +18,14 @@ extraSecrets:
     type: Opaque
     stringData: |
       fernet-key: "{{ .Values.secrets.fernet.key }}"
-  airflow-webserver-secret-key:
+  airflow-api-secret-key:
     type: Opaque
     stringData: |
-      webserver-secret-key: "{{ .Values.secrets.webserver.key }}"
+      api-secret-key: "{{ .Values.secrets.api.secretKey }}"
+  airflow-jwt-secret:
+    type: Opaque
+    stringData: |
+      jwt-secret: "{{ .Values.secrets.api.jwtKey }}"
   airflow-migrate-db-conn:
     type: Opaque
     stringData: |
@@ -43,7 +47,8 @@ extraSecrets:
       }'
 
 fernetKeySecretName: airflow-fernet-key
-webserverSecretKeySecretName: airflow-webserver-secret-key
+apiSecretKeySecretName: airflow-api-secret-key
+jwtSecretName: airflow-jwt-secret
 
 data:
   metadataSecretName: airflow-rw-db-conn
@@ -54,7 +59,7 @@ logs:
     storageClassName: netapp-file-standard
     size: 8Gi
 
-airflowVersion: "2.10.5"
+airflowVersion: "3.1.7"
 
 images:
   airflow:
@@ -62,7 +67,11 @@ images:
     tag: latest
     pullPolicy: Always
 
-webserver:
+securityContext:
+  runAsUser: 1017940000
+  fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
+
+apiServer:
   startupProbe:
     timeoutSeconds: 60
   env:
@@ -70,6 +79,10 @@ webserver:
       value: "False"
     - name: ENVIRONMENT
       value: PRODUCTION
+    - name: AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME
+      value: "21600"
+    - name: AIRFLOW__API_AUTH__JWT_LEEWAY
+      value: "60"
   resources:
     limits:
       memory: 2G
@@ -110,9 +123,6 @@ webserver:
           memory: 1G
   waitForMigrations:
     enabled: true
-  securityContext:
-    runAsUser: 1017940000
-    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
 
 scheduler:
   env:
@@ -120,6 +130,10 @@ scheduler:
       value: "False"
     - name: ENVIRONMENT
       value: PRODUCTION
+    - name: AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME
+      value: "21600"
+    - name: AIRFLOW__API_AUTH__JWT_LEEWAY
+      value: "60"
   resources:
     limits:
       memory: 2G
@@ -127,9 +141,6 @@ scheduler:
       memory: 2G
   waitForMigrations:
     enabled: true
-  securityContext:
-    runAsUser: 1017940000
-    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
 
 migrateDatabaseJob:
   env:
@@ -155,9 +166,6 @@ migrateDatabaseJob:
       memory: 1G
     limits:
       memory: 1G
-  securityContext:
-    runAsUser: 1017940000
-    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
   ttlSecondsAfterFinished: 180
 
 createUserJob:
@@ -184,9 +192,6 @@ createUserJob:
       memory: 1G
     limits:
       memory: 1G
-  securityContext:
-    runAsUser: 1017940000
-    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
   ttlSecondsAfterFinished: 180
 
 redis:
@@ -198,6 +203,10 @@ triggerer:
       value: "False"
     - name: ENVIRONMENT
       value: PRODUCTION
+    - name: AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME
+      value: "21600"
+    - name: AIRFLOW__API_AUTH__JWT_LEEWAY
+      value: "60"
   resources:
     limits:
       memory: 1.5G
@@ -207,9 +216,6 @@ triggerer:
     enabled: false
   waitForMigrations:
     enabled: true
-  securityContext:
-    runAsUser: 1017940000
-    fsGroup: 1017940000      # a value within the allowed fsGroup range (1017940000/10000)
 
 postgresql:
   enabled: false

--- a/charts/openshift/airflow/values.test.yaml
+++ b/charts/openshift/airflow/values.test.yaml
@@ -4,9 +4,9 @@ config:
   core:
     min_serialized_dag_update_interval: 300
     min_serialized_dag_fetch_interval: 60
-  scheduler:
-    dag_dir_list_interval: 3600
+  dag_processor:
     min_file_process_interval: 300
+    refresh_interval: 3600
 
 extraSecrets:
   airflow-flowworks-credentials:
@@ -18,10 +18,14 @@ extraSecrets:
     type: Opaque
     stringData: |
       fernet-key: "{{ .Values.secrets.fernet.key }}"
-  airflow-webserver-secret-key:
+  airflow-api-secret-key:
     type: Opaque
     stringData: |
-      webserver-secret-key: "{{ .Values.secrets.webserver.key }}"
+      api-secret-key: "{{ .Values.secrets.api.secretKey }}"
+  airflow-jwt-secret:
+    type: Opaque
+    stringData: |
+      jwt-secret: "{{ .Values.secrets.api.jwtKey }}"
   airflow-migrate-db-conn:
     type: Opaque
     stringData: |
@@ -43,7 +47,8 @@ extraSecrets:
       }'
 
 fernetKeySecretName: airflow-fernet-key
-webserverSecretKeySecretName: airflow-webserver-secret-key
+apiSecretKeySecretName: airflow-api-secret-key
+jwtSecretName: airflow-jwt-secret
 
 data:
   metadataSecretName: airflow-rw-db-conn
@@ -54,7 +59,7 @@ logs:
     storageClassName: netapp-file-standard
     size: 8Gi
 
-airflowVersion: "2.10.5"
+airflowVersion: "3.1.7"
 
 images:
   airflow:
@@ -62,7 +67,11 @@ images:
     tag: latest
     pullPolicy: Always
 
-webserver:
+securityContext:
+  runAsUser: 1017950000
+  fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
+
+apiServer:
   startupProbe:
     timeoutSeconds: 60
   env:
@@ -70,6 +79,10 @@ webserver:
       value: "False"
     - name: ENVIRONMENT
       value: TEST
+    - name: AIRFLOW__EXECUTION_API__JWT_EXPIRATION_TIME
+      value: "21600"
+    - name: AIRFLOW__API_AUTH__JWT_LEEWAY
+      value: "60"
   resources:
     limits:
       memory: 2G
@@ -110,9 +123,6 @@ webserver:
           memory: 1G
   waitForMigrations:
     enabled: true
-  securityContext:
-    runAsUser: 1017950000
-    fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
 
 scheduler:
   env:
@@ -127,9 +137,6 @@ scheduler:
       memory: 2G
   waitForMigrations:
     enabled: true
-  securityContext:
-    runAsUser: 1017950000
-    fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
 
 migrateDatabaseJob:
   env:
@@ -155,9 +162,6 @@ migrateDatabaseJob:
       memory: 1G
     limits:
       memory: 1G
-  securityContext:
-    runAsUser: 1017950000
-    fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
   ttlSecondsAfterFinished: 180
 
 createUserJob:
@@ -184,9 +188,6 @@ createUserJob:
       memory: 1G
     limits:
       memory: 1G
-  securityContext:
-    runAsUser: 1017950000
-    fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
   ttlSecondsAfterFinished: 180
 
 triggerer:
@@ -204,9 +205,6 @@ triggerer:
     enabled: false
   waitForMigrations:
     enabled: true
-  securityContext:
-    runAsUser: 1017950000
-    fsGroup: 1017950000      # a value within the allowed fsGroup range (1017950000/10000)
 
 redis:
   enabled: false


### PR DESCRIPTION
# Description

I have upgraded our OKD Airflow environment to 3.1.7.

It looks to me as though this environment is stable - the pinning of the FAB version to 3.1.2 has alleviated all of the previous crash loops/issues communicating with the DB.

Please take a look at the configs of both our openshift pod templates, and our okd pod templates, as well as the values files, and let me know if you find any inconsistencies.

They should nearly be 1:1, apart from some security config stuff.

Also, I created the github secrets that will create the openshift secrets for the jwt token/api secret key etc.  

Once we push dev -> main, this will get deployed to Openshift Dev/Test. I think if we let it run for a week and monitor, ensuring each DAG successfully completes (manually running the quarterly ones) we are safe to promote to Prod.