### PR TITLE
updated quantity value from ann_adjust

### DIFF
--- a/client/src/components/watershed/report/Allocations.vue
+++ b/client/src/components/watershed/report/Allocations.vue
@@ -124,7 +124,7 @@
                                             </p>
                                         </td>
                                         <td>
-                                            {{ addCommas((+bodyProps.row.ann_adjust || 0).toFixed(1)) }}
+                                            {{ addCommas((+bodyProps.row.display_ann_qty || 0).toFixed(1)) }}
                                         </td>
                                         <td>
                                             {{ bodyProps.row.qty_flag }}


### PR DESCRIPTION
Addressing issue raised by MW:

```
Had a user raise an issue with the PDF incorrectly displaying some Allocations with the Quantity (m3/year) as 0.0. I was able to confirm the issue and attached is a word doc describing the error with examples and screenshots, as well as the corresponding PDF report.

Issue seems to be specific to E-licencing allocations that have term dates on their purpose use and need the conversion from m3/day to m3/year. Allocations display correctly within the browser of the Watershed Report tool, issue seems specific to PDF.
```