### PR TITLE
Fix Ariflow Dockerfile - Necessary for Psycopg2

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -12,6 +12,12 @@ RUN chown -R airflow: /opt/airflow/dags /opt/airflow/etl_pipelines /opt/airflow/
 
 ENV PYTHONPATH = "/opt/airflow/etl_pipelines:${PYTHONPATH}"
 
+# Install the PostgreSQL development libraries and a C compiler
+RUN apt-get update && apt-get install -y \
+    gcc \
+    libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY requirements.txt .
 
 # Switch to airflow user for pip installations


### PR DESCRIPTION
Fix Docker File - issue building psycopg2.

https://github.com/bcgov/nr-bcwat/actions/runs/26839526620/job/79162399344

I do not want to use psycopg2 binary.