### PR TITLE
Fix Typo

### DIFF
--- a/charts/airflow/values.dev.yaml
+++ b/charts/airflow/values.dev.yaml
@@ -335,7 +335,6 @@ podTemplate: |
                 key: subject-prefix
           - name: PLATFORM
             value: OPENSHIFT
-          - name:
         resources:
           requests:
             memory: 2048Mi

--- a/charts/airflow/values.prod.yaml
+++ b/charts/airflow/values.prod.yaml
@@ -340,7 +340,6 @@ podTemplate: |
                 key: subject-prefix
           - name: PLATFORM
             value: OPENSHIFT
-          - name:
         resources:
           requests:
             memory: 2048Mi

--- a/charts/airflow/values.test.yaml
+++ b/charts/airflow/values.test.yaml
@@ -329,7 +329,6 @@ podTemplate: |
                 key: subject-prefix
           - name: PLATFORM
             value: OPENSHIFT
-          - name:
         resources:
           requests:
             memory: 2048Mi


### PR DESCRIPTION
# Description

Scheduler could not start due to blank environment variable.

```
  File "/home/airflow/.local/lib/python3.12/site-packages/kubernetes/client/models/v1_env_var.py", line 85, in name
    raise ValueError("Invalid value for `name`, must not be `None`")  # noqa: E501
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: Invalid value for `name`, must not be `None`
2026-06-18T17:58:26.981628Z [info     ] Shutting down Kubernetes executor [airflow.providers.cncf.kubernetes.executors.kubernetes_executor.KubernetesExecutor] loc=kubernetes_executor.py:729
```
