### PR TITLE
Initialize 3 Pods per Production Deployment - replicas

### DIFF
--- a/charts/app/templates/backend/templates/deployment.yaml
+++ b/charts/app/templates/backend/templates/deployment.yaml
@@ -8,9 +8,7 @@ metadata:
 spec:
   strategy:
     type: {{ .Values.backend.deploymentStrategy }}
-  {{- if not .Values.backend.autoscaling.enabled }}
-  replicas: {{ .Values.backend.replicaCount }}
-  {{- end }}
+  replicas: {{ .Values.backend.replicas }}
   selector:
     matchLabels:
       {{- include "backend.selectorLabels" . | nindent 6 }}

--- a/charts/app/templates/frontend/templates/deployment.yaml
+++ b/charts/app/templates/frontend/templates/deployment.yaml
@@ -8,9 +8,7 @@ metadata:
 spec:
   strategy:
     type: {{ .Values.frontend.deploymentStrategy }}
-  {{- if not .Values.frontend.autoscaling.enabled }}
-  replicas: {{ .Values.frontend.replicaCount }}
-  {{- end }}
+  replicas: {{ .Values.frontend.replicas }}
   selector:
     matchLabels:
       {{- include "frontend.selectorLabels" . | nindent 6 }}

--- a/charts/app/values.prod.yaml
+++ b/charts/app/values.prod.yaml
@@ -28,16 +28,8 @@ backend:
   enabled: true
   #-- the deployment strategy, can be "Recreate" or "RollingUpdate"
   deploymentStrategy: Recreate
-  #-- autoscaling for the component. it is optional and is an object.
-  autoscaling:
-    #-- enable or disable autoscaling.
-    enabled: true
-    #-- the minimum number of replicas.
-    minReplicas: 3
-    #-- the maximum number of replicas.
-    maxReplicas: 7
-    #-- the target cpu utilization percentage, is from request cpu and NOT LIMIT CPU.
-    targetCPUUtilizationPercentage: 80
+  #-- the number of replicas - 3 pods for production deployments
+  replicas: 3
   #-- vault, for injecting secrets from vault. it is optional and is an object. it creates an initContainer which reads from vault and app container can source those secrets. for referring to a working example with vault follow this link: https://github.com/bcgov/onroutebc/blob/main/charts/onroutebc/values.yaml#L171-L186
   vault:
     #-- enable or disable vault.
@@ -75,17 +67,8 @@ frontend:
   enabled: true
   # -- the deployment strategy, can be "Recreate" or "RollingUpdate"
   deploymentStrategy: Recreate
-
-  #-- autoscaling for the component. it is optional and is an object.
-  autoscaling:
-    #-- enable or disable autoscaling.
-    enabled: true
-    #-- the minimum number of replicas.
-    minReplicas: 3
-    #-- the maximum number of replicas.
-    maxReplicas: 7
-    #-- the target cpu utilization percentage, is from request cpu and NOT LIMIT CPU.
-    targetCPUUtilizationPercentage: 80
+  #-- the number of replicas - 3 pods for production deployments
+  replicas: 3
   #-- the service for the component. for inter namespace communication, use the service name as the hostname.
   service:
     #-- enable or disable the service.

--- a/charts/app/values.test.yaml
+++ b/charts/app/values.test.yaml
@@ -29,7 +29,7 @@ backend:
   #-- the deployment strategy, can be "Recreate" or "RollingUpdate"
   deploymentStrategy: Recreate
   #-- the number of replicas
-  replicas: 1
+  replicas: 3
   #-- vault, for injecting secrets from vault. it is optional and is an object. it creates an initContainer which reads from vault and app container can source those secrets. for referring to a working example with vault follow this link: https://github.com/bcgov/onroutebc/blob/main/charts/onroutebc/values.yaml#L171-L186
   vault:
     #-- enable or disable vault.
@@ -68,7 +68,7 @@ frontend:
   # -- the deployment strategy, can be "Recreate" or "RollingUpdate"
   deploymentStrategy: Recreate
   #-- the number of replicas
-  replicas: 1
+  replicas: 3
   #-- the service for the component. for inter namespace communication, use the service name as the hostname.
   service:
     #-- enable or disable the service.

--- a/charts/app/values.test.yaml
+++ b/charts/app/values.test.yaml
@@ -28,16 +28,8 @@ backend:
   enabled: true
   #-- the deployment strategy, can be "Recreate" or "RollingUpdate"
   deploymentStrategy: Recreate
-  #-- autoscaling for the component. it is optional and is an object.
-  autoscaling:
-    #-- enable or disable autoscaling.
-    enabled: true
-    #-- the minimum number of replicas.
-    minReplicas: 3
-    #-- the maximum number of replicas.
-    maxReplicas: 7
-    #-- the target cpu utilization percentage, is from request cpu and NOT LIMIT CPU.
-    targetCPUUtilizationPercentage: 80
+  #-- the number of replicas
+  replicas: 1
   #-- vault, for injecting secrets from vault. it is optional and is an object. it creates an initContainer which reads from vault and app container can source those secrets. for referring to a working example with vault follow this link: https://github.com/bcgov/onroutebc/blob/main/charts/onroutebc/values.yaml#L171-L186
   vault:
     #-- enable or disable vault.
@@ -75,17 +67,8 @@ frontend:
   enabled: true
   # -- the deployment strategy, can be "Recreate" or "RollingUpdate"
   deploymentStrategy: Recreate
-
-  #-- autoscaling for the component. it is optional and is an object.
-  autoscaling:
-    #-- enable or disable autoscaling.
-    enabled: true
-    #-- the minimum number of replicas.
-    minReplicas: 3
-    #-- the maximum number of replicas.
-    maxReplicas: 7
-    #-- the target cpu utilization percentage, is from request cpu and NOT LIMIT CPU.
-    targetCPUUtilizationPercentage: 80
+  #-- the number of replicas
+  replicas: 1
   #-- the service for the component. for inter namespace communication, use the service name as the hostname.
   service:
     #-- enable or disable the service.

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -28,16 +28,8 @@ backend:
   enabled: true
   #-- the deployment strategy, can be "Recreate" or "RollingUpdate"
   deploymentStrategy: Recreate
-  #-- autoscaling for the component. it is optional and is an object.
-  autoscaling:
-    #-- enable or disable autoscaling.
-    enabled: true
-    #-- the minimum number of replicas.
-    minReplicas: 3
-    #-- the maximum number of replicas.
-    maxReplicas: 7
-    #-- the target cpu utilization percentage, is from request cpu and NOT LIMIT CPU.
-    targetCPUUtilizationPercentage: 80
+  #-- the number of replicas
+  replicas: 1
   #-- vault, for injecting secrets from vault. it is optional and is an object. it creates an initContainer which reads from vault and app container can source those secrets. for referring to a working example with vault follow this link: https://github.com/bcgov/onroutebc/blob/main/charts/onroutebc/values.yaml#L171-L186
   vault:
     #-- enable or disable vault.
@@ -74,17 +66,8 @@ frontend:
   enabled: true
   # -- the deployment strategy, can be "Recreate" or "RollingUpdate"
   deploymentStrategy: Recreate
-
-  #-- autoscaling for the component. it is optional and is an object.
-  autoscaling:
-    #-- enable or disable autoscaling.
-    enabled: true
-    #-- the minimum number of replicas.
-    minReplicas: 3
-    #-- the maximum number of replicas.
-    maxReplicas: 7
-    #-- the target cpu utilization percentage, is from request cpu and NOT LIMIT CPU.
-    targetCPUUtilizationPercentage: 80
+  #-- the number of replicas
+  replicas: 1
   #-- the service for the component. for inter namespace communication, use the service name as the hostname.
   service:
     #-- enable or disable the service.


### PR DESCRIPTION
# Description

Initialize Multiple Pods per Production Deployment as per BCGov Request,

Only API/Frontend Pods for the time being.

Setting 3 replicas on Test to validate proper functionality - if all works as expected, I will revert to 1 pod and make another PR before merging to production. 